### PR TITLE
security/devops: allow gitleaks PR reads [P0-A3]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         node-version: [22, 24]
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
## Criterion IDs
- P0-A3
- P10-A3 support path: keeps gitleaks runnable in PR CI

## Files changed
- `.github/workflows/ci.yml`

## Verification
- `npm ci` passed before first push
- `npm run check` passed after latest workflow update
- `npm run audit:security` passed after latest workflow update
- `docker compose config --quiet` passed
- `npm exec -- prettier --check .github/workflows/ci.yml` passed
- Workflow failure review confirmed gitleaks needs `pull-requests: read` and full checkout history for PR commit range scanning

## Risks
- Minimal permission increase: read-only pull request metadata for CI.
- Full checkout history increases CI clone time, but only for repository history access needed by gitleaks.
- CI rerun must confirm Node 22 and 24 are green.

## Docker impact
- None. No Dockerfile, compose, image, or runtime container behavior changed.