### PR TITLE
Stabilize pre-push hook test timeout

### DIFF
--- a/tests/pre-push-hook.test.ts
+++ b/tests/pre-push-hook.test.ts
@@ -8,20 +8,22 @@ const shell = findShell();
 const testWithShell = shell ? it : it.skip;
 
 describe("target repo pre-push hook", () => {
-  testWithShell("scans the pushed commit range instead of staged files", () => {
-    const syntheticSecret = ["AKIA", "IOSFODNN7", "EXAMPLE"].join("");
-    const root = join(tmpdir(), `pre-push-hook-${process.pid}-${Date.now()}`);
-    const repo = join(root, "repo");
-    const bin = join(root, "bin");
-    const argsFile = join(root, "gitleaks-args.txt");
-    const hook = join(process.cwd(), "templates", "target-repo", ".agent-team", "hooks", "pre-push");
-    mkdirSync(repo, { recursive: true });
-    mkdirSync(bin, { recursive: true });
+  testWithShell(
+    "scans the pushed commit range instead of staged files",
+    () => {
+      const syntheticSecret = ["AKIA", "IOSFODNN7", "EXAMPLE"].join("");
+      const root = join(tmpdir(), `pre-push-hook-${process.pid}-${Date.now()}`);
+      const repo = join(root, "repo");
+      const bin = join(root, "bin");
+      const argsFile = join(root, "gitleaks-args.txt");
+      const hook = join(process.cwd(), "templates", "target-repo", ".agent-team", "hooks", "pre-push");
+      mkdirSync(repo, { recursive: true });
+      mkdirSync(bin, { recursive: true });
 
-    try {
-      writeFileSync(
-        join(bin, "gitleaks"),
-        `#!/usr/bin/env sh
+      try {
+        writeFileSync(
+          join(bin, "gitleaks"),
+          `#!/usr/bin/env sh
 printf '%s\\n' "$@" > "$GITLEAKS_ARGS_FILE"
 [ "$1" = "git" ] || exit 2
 previous=
@@ -39,43 +41,45 @@ if git log -p "$log_opts" | grep -q "$SYNTHETIC_SECRET"; then
 fi
 exit 0
 `,
-        "utf8"
-      );
-      chmodSync(join(bin, "gitleaks"), 0o755);
+          "utf8"
+        );
+        chmodSync(join(bin, "gitleaks"), 0o755);
 
-      execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
-      execFileSync("git", ["config", "user.email", "codex@example.com"], { cwd: repo, stdio: "ignore" });
-      execFileSync("git", ["config", "user.name", "Codex"], { cwd: repo, stdio: "ignore" });
-      writeFileSync(join(repo, "README.md"), "base\n", "utf8");
-      execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
-      execFileSync("git", ["commit", "-m", "base"], { cwd: repo, stdio: "ignore" });
-      const baseSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).trim();
+        execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+        execFileSync("git", ["config", "user.email", "codex@example.com"], { cwd: repo, stdio: "ignore" });
+        execFileSync("git", ["config", "user.name", "Codex"], { cwd: repo, stdio: "ignore" });
+        writeFileSync(join(repo, "README.md"), "base\n", "utf8");
+        execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
+        execFileSync("git", ["commit", "-m", "base"], { cwd: repo, stdio: "ignore" });
+        const baseSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).trim();
 
-      writeFileSync(join(repo, "secret.txt"), `${syntheticSecret}\n`, "utf8");
-      execFileSync("git", ["add", "secret.txt"], { cwd: repo, stdio: "ignore" });
-      execFileSync("git", ["commit", "-m", "add synthetic secret"], { cwd: repo, stdio: "ignore" });
-      const headSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).trim();
-      const env = shellEnv(bin, argsFile, syntheticSecret);
+        writeFileSync(join(repo, "secret.txt"), `${syntheticSecret}\n`, "utf8");
+        execFileSync("git", ["add", "secret.txt"], { cwd: repo, stdio: "ignore" });
+        execFileSync("git", ["commit", "-m", "add synthetic secret"], { cwd: repo, stdio: "ignore" });
+        const headSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).trim();
+        const env = shellEnv(bin, argsFile, syntheticSecret);
 
-      expect(() =>
-        execFileSync(shell!, [hook], {
-          cwd: repo,
-          input: `refs/heads/main ${headSha} refs/heads/main ${baseSha}\n`,
-          env,
-          stdio: ["pipe", "pipe", "pipe"]
-        })
-      ).toThrow();
+        expect(() =>
+          execFileSync(shell!, [hook], {
+            cwd: repo,
+            input: `refs/heads/main ${headSha} refs/heads/main ${baseSha}\n`,
+            env,
+            stdio: ["pipe", "pipe", "pipe"]
+          })
+        ).toThrow();
 
-      const args = readFileSync(argsFile, "utf8");
-      expect(args).toContain("git");
-      expect(args).toContain("--log-opts");
-      expect(args).toContain(`${baseSha}..${headSha}`);
-      expect(args).toContain("--redact");
-      expect(args).not.toContain("--staged");
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
+        const args = readFileSync(argsFile, "utf8");
+        expect(args).toContain("git");
+        expect(args).toContain("--log-opts");
+        expect(args).toContain(`${baseSha}..${headSha}`);
+        expect(args).toContain("--redact");
+        expect(args).not.toContain("--staged");
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    20_000
+  );
 });
 
 function findShell(): string | null {


### PR DESCRIPTION
## Summary
- Give the shell-based pre-push hook regression test an explicit 20s timeout.
- Keeps the fix scoped to the flaky full-suite timeout observed during local verification.

## Validation
- npm exec vitest run tests/pre-push-hook.test.ts
- npm run check
- npm run test:e2e
- npm run audit:security
- npm run logs:check
- docker compose config --no-interpolate --quiet
- git diff --check

## Notes
All Codex automations remain paused; this PR only stabilizes a test gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to include explicit timeout settings for improved test stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->