### PR TITLE
Harden native automation preflight and Janitor cleanup

### DIFF
--- a/scripts/janitor.mjs
+++ b/scripts/janitor.mjs
@@ -34,7 +34,6 @@ for (const tree of worktrees) {
   if (safe && apply) {
     try {
       await run("git", ["worktree", "remove", "--force", treePath]);
-      removed = !existsSync(treePath);
       emptyResidueRemoved = removeEmptyDir(treePath);
       removeEmptyDir(dirname(treePath));
     } catch (error) {
@@ -42,6 +41,7 @@ for (const tree of worktrees) {
       emptyResidueRemoved = removeEmptyDir(treePath);
       if (emptyResidueRemoved) removeEmptyDir(dirname(treePath));
     }
+    removed = !existsSync(treePath);
   }
 
   results.push({

--- a/scripts/janitor.mjs
+++ b/scripts/janitor.mjs
@@ -1,4 +1,5 @@
-import { statSync } from "node:fs";
+import { existsSync, readdirSync, rmdirSync, statSync } from "node:fs";
+import { dirname } from "node:path";
 import { capture, run } from "./verify-lib.mjs";
 
 const apply = process.argv.includes("--apply");
@@ -27,6 +28,22 @@ for (const tree of worktrees) {
   const stale = !probeError && mtime < cutoff;
   const safe = !probeError && !status && !openPr && stale;
 
+  let removed = false;
+  let emptyResidueRemoved = false;
+  let removeError = null;
+  if (safe && apply) {
+    try {
+      await run("git", ["worktree", "remove", "--force", treePath]);
+      removed = !existsSync(treePath);
+      emptyResidueRemoved = removeEmptyDir(treePath);
+      removeEmptyDir(dirname(treePath));
+    } catch (error) {
+      removeError = error instanceof Error ? error.message : String(error);
+      emptyResidueRemoved = removeEmptyDir(treePath);
+      if (emptyResidueRemoved) removeEmptyDir(dirname(treePath));
+    }
+  }
+
   results.push({
     path: treePath,
     branch,
@@ -36,11 +53,11 @@ for (const tree of worktrees) {
     probeError,
     openPr,
     stale,
-    safe
+    safe,
+    removed,
+    emptyResidueRemoved,
+    removeError
   });
-  if (safe && apply) {
-    await run("git", ["worktree", "remove", treePath]);
-  }
 }
 
 console.log(JSON.stringify({ apply, maxAgeHours, worktrees: results }, null, 2));
@@ -67,6 +84,17 @@ async function hasOpenPr(branch) {
     return JSON.parse(output).length > 0;
   } catch {
     return true;
+  }
+}
+
+function removeEmptyDir(path) {
+  try {
+    if (!existsSync(path)) return false;
+    if (readdirSync(path, { withFileTypes: true }).length) return false;
+    rmdirSync(path);
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/scripts/preflight-policy.mjs
+++ b/scripts/preflight-policy.mjs
@@ -21,7 +21,7 @@ function canonicalStage(stage) {
 }
 
 function normalizeStage(stage) {
-  return String(stage || "")
+  return String(stage ?? "")
     .trim()
     .toLowerCase();
 }

--- a/scripts/preflight-policy.mjs
+++ b/scripts/preflight-policy.mjs
@@ -1,7 +1,23 @@
-const PAUSE_BYPASS_STAGES = new Set(["meta-health"]);
+const PAUSE_BYPASS_STAGES = new Set(["research", "meta-health", "janitor"]);
+const STAGE_ALIASES = new Map([
+  ["0", "research"],
+  ["r&d", "research"],
+  ["rnd", "research"],
+  ["feature-pipeline", "research"],
+  ["7", "meta-health"],
+  ["meta", "meta-health"],
+  ["automation-health", "meta-health"],
+  ["8", "janitor"],
+  ["ops-janitor", "janitor"]
+]);
 
 export function canRunWhenControlPaused(stage) {
-  return PAUSE_BYPASS_STAGES.has(normalizeStage(stage));
+  return PAUSE_BYPASS_STAGES.has(canonicalStage(stage));
+}
+
+function canonicalStage(stage) {
+  const normalized = normalizeStage(stage);
+  return STAGE_ALIASES.get(normalized) || normalized;
 }
 
 function normalizeStage(stage) {

--- a/tests/preflight-policy.test.mjs
+++ b/tests/preflight-policy.test.mjs
@@ -5,6 +5,7 @@ describe("preflight pause policy", () => {
   it("lets control-plane lanes run while the control plane is paused", () => {
     expect(canRunWhenControlPaused("research")).toBe(true);
     expect(canRunWhenControlPaused("0")).toBe(true);
+    expect(canRunWhenControlPaused(0)).toBe(true);
     expect(canRunWhenControlPaused("r&d")).toBe(true);
     expect(canRunWhenControlPaused("meta-health")).toBe(true);
     expect(canRunWhenControlPaused("  META-HEALTH  ")).toBe(true);

--- a/tests/preflight-policy.test.mjs
+++ b/tests/preflight-policy.test.mjs
@@ -2,11 +2,16 @@ import { describe, expect, it } from "vitest";
 import { canRunWhenControlPaused } from "../scripts/preflight-policy.mjs";
 
 describe("preflight pause policy", () => {
-  it("lets only Meta Health run while the control plane is paused", () => {
+  it("lets control-plane lanes run while the control plane is paused", () => {
+    expect(canRunWhenControlPaused("research")).toBe(true);
+    expect(canRunWhenControlPaused("0")).toBe(true);
+    expect(canRunWhenControlPaused("r&d")).toBe(true);
     expect(canRunWhenControlPaused("meta-health")).toBe(true);
     expect(canRunWhenControlPaused("  META-HEALTH  ")).toBe(true);
+    expect(canRunWhenControlPaused("7")).toBe(true);
+    expect(canRunWhenControlPaused("janitor")).toBe(true);
+    expect(canRunWhenControlPaused("8")).toBe(true);
     expect(canRunWhenControlPaused("backend-core")).toBe(false);
-    expect(canRunWhenControlPaused("janitor")).toBe(false);
     expect(canRunWhenControlPaused("captain")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- allow Research/R&D and Janitor preflight checks to run while `control.paused=true`, alongside Meta Health
- make Janitor continue after per-worktree Windows removal failures and surface `removeError` in JSON output
- keep cleanup scoped to clean stale Codex worktrees under `.codex\worktrees` with no open PR branch
- update the preflight pause-policy test to cover Research/Janitor aliases and keep build/Captain lanes blocked

## Verification
- `npx prettier --check scripts/preflight-policy.mjs scripts/janitor.mjs tests/preflight-policy.test.mjs`
- `npx eslint scripts/preflight-policy.mjs scripts/janitor.mjs tests/preflight-policy.test.mjs`
- `npx vitest run tests/preflight-policy.test.mjs tests/bulk-automation-status.test.mjs`
- `node scripts/janitor.mjs --max-age-hours=24`
- `npm run diff:budget`

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust cleanup: removals are now attempted per-worktree, with each item reporting whether it was removed, whether any empty parent residue was deleted, and any error messages encountered.

* **New Features**
  * Policy checks now normalize and recognize additional stage aliases (including numeric and named variants) and treat new stages as allowed while control is paused.

* **Tests**
  * Updated tests to reflect the expanded policy allowlist and alias handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->