### PR TITLE
Resolve Temporalio uuid Dependabot alert

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -2,19 +2,19 @@
 
 ## Dependency Audit
 
-`npm audit --audit-level=moderate` currently reports a moderate advisory for `uuid@11.1.0` through the Temporal TypeScript SDK dependency chain.
+`npm audit --audit-level=moderate` must pass with zero production dependency vulnerabilities.
 
 Current status:
 
-- `npm audit fix` cannot resolve it.
-- `npm audit fix --force` proposes a breaking downgrade of `@temporalio/worker`, so it is not applied.
-- The project does not call the affected `uuid` buffer APIs directly.
+- The Temporal TypeScript SDK currently resolves its transitive `uuid` dependency through the root `overrides` policy in `package.json`.
+- `npm run audit:security` treats production `moderate`, `high`, and `critical` advisories as blocking.
+- A dependency override must be validated against the runtime imports that consume it before merge.
 
 Operational mitigation:
 
 - Keep Temporal packages current.
-- CI blocks high-or-worse advisories and runs `npm run audit:security`, which allows only the documented Temporal/uuid moderate advisory. Any additional production moderate advisory fails CI.
-- Replace or override the dependency only after Temporal publishes a compatible fix or after validating an override against the worker runtime.
+- CI runs `npm run audit:security` and fails on every production moderate-or-worse advisory.
+- Remove dependency overrides after upstream packages publish compatible fixed dependency ranges.
 
 ## Code Scanning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7264,16 +7264,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -78,5 +78,8 @@
     "typescript-eslint": "^8.59.0",
     "vite": "^6.4.2",
     "vitest": "^3.2.4"
+  },
+  "overrides": {
+    "uuid": "14.0.0"
   }
 }

--- a/scripts/check-npm-audit.mjs
+++ b/scripts/check-npm-audit.mjs
@@ -1,13 +1,5 @@
 import { execSync } from "node:child_process";
 
-const allowedModerate = new Set([
-  "@temporalio/activity",
-  "@temporalio/client",
-  "@temporalio/nexus",
-  "@temporalio/worker",
-  "uuid"
-]);
-
 let report;
 try {
   execSync("npm audit --omit=dev --json", { stdio: ["ignore", "pipe", "pipe"] });
@@ -23,18 +15,14 @@ try {
 }
 
 const vulnerabilities = Object.values(report.vulnerabilities || {});
-const unexpected = vulnerabilities.filter((vulnerability) => {
-  if (vulnerability.severity === "high" || vulnerability.severity === "critical") return true;
-  if (vulnerability.severity === "moderate") return !allowedModerate.has(vulnerability.name);
-  return false;
-});
+const unexpected = vulnerabilities.filter((vulnerability) =>
+  ["moderate", "high", "critical"].includes(vulnerability.severity)
+);
 
 if (unexpected.length) {
-  console.error("Unexpected production dependency vulnerabilities:");
+  console.error("Production dependency vulnerabilities found:");
   for (const vulnerability of unexpected) {
     console.error(`- ${vulnerability.name}: ${vulnerability.severity}`);
   }
   process.exit(1);
 }
-
-console.warn("Only the documented Temporal/uuid moderate advisory is present.");


### PR DESCRIPTION
## Summary
- overrides Temporalio's transitive `uuid` dependency to `14.0.0`
- verifies `@temporalio/client` can still load `uuid@14` through CommonJS
- removes the old Temporalio/uuid moderate-advisory allowlist from `audit:security`

## Verification
- npm ls uuid
- npm audit --json
- npm run audit:security
- npm audit --audit-level=high
- npm audit --audit-level=moderate
- node -e "const uuid=require('uuid'); console.log(require('uuid/package.json').version); console.log(typeof uuid.v4, uuid.v4()); const client=require('@temporalio/client'); console.log(typeof client.Client, typeof client.Connection);"
- npm run typecheck
- npm test
- npm run lint
- npm run format:check
- npm run build
- npm run check
- npm run logs:check
- npm run spec:hash
- coderabbit review --agent -t uncommitted -c AGENTS.md -c .coderabbit.yaml: 0 issues

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution to enforce a consistent package version across the project.
  * Strengthened CI audit behavior to treat moderate-or-worse production vulnerabilities as failures.

* **Documentation**
  * Security guidance updated to require zero production moderate-or-worse vulnerabilities and to document how temporary overrides should be validated and reverted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->