### PR TITLE
Move native Codex control plane to cloud workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: codeql-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codex-ci-autofix.yml
+++ b/.github/workflows/codex-ci-autofix.yml
@@ -17,6 +17,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: codex-ci-autofix-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/codex-cloud-meta-health.yml
+++ b/.github/workflows/codex-cloud-meta-health.yml
@@ -1,0 +1,244 @@
+name: Codex Cloud Meta Health
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  issues: write
+  pull-requests: read
+  security-events: read
+  statuses: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: codex-cloud-meta-health
+  cancel-in-progress: true
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Reconcile GitHub control-plane truth
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          HAS_CODEX_HEALTH_TOKEN: ${{ secrets.CODEX_HEALTH_TOKEN != '' }}
+        with:
+          github-token: ${{ secrets.CODEX_HEALTH_TOKEN || github.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const now = new Date().toISOString();
+            const blockers = [];
+            const warnings = [];
+
+            const branch = await github.rest.repos.getBranch({ owner, repo, branch: "main" });
+            const mainSha = branch.data.commit.sha;
+
+            let protection = null;
+            try {
+              protection = (await github.rest.repos.getBranchProtection({ owner, repo, branch: "main" })).data;
+            } catch (error) {
+              warnings.push({
+                class: "advisory",
+                title: "main branch protection is unavailable",
+                detail: `Branch protection lookup failed: ${
+                  error.status || "unknown"
+                }; admin-read token access may be required for exact required-check reconciliation.`
+              });
+            }
+
+            const requiredContexts = [
+              ...(protection?.required_status_checks?.contexts || []),
+              ...(protection?.required_status_checks?.checks || []).map((check) => check.context)
+            ].filter((contextName, index, contexts) => contextName && contexts.indexOf(contextName) === index);
+            const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+              owner,
+              repo,
+              ref: mainSha,
+              per_page: 100
+            });
+            const latestStatusByContext = new Map();
+            for (const run of checkRuns) {
+              setLatestStatus(latestStatusByContext, run.name, {
+                kind: "check-run",
+                status: run.status,
+                conclusion: run.conclusion,
+                observedAt: run.started_at || run.created_at
+              });
+            }
+
+            const commitStatuses = await github.paginate(github.rest.repos.listCommitStatusesForRef, {
+              owner,
+              repo,
+              ref: mainSha,
+              per_page: 100
+            });
+            for (const status of commitStatuses) {
+              setLatestStatus(latestStatusByContext, status.context, {
+                kind: "commit-status",
+                status: "completed",
+                conclusion: status.state,
+                observedAt: status.updated_at || status.created_at
+              });
+            }
+
+            function setLatestStatus(map, name, value) {
+              const existing = map.get(name);
+              if (!existing || new Date(value.observedAt) > new Date(existing.observedAt)) {
+                map.set(name, value);
+              }
+            }
+
+            const passingConclusions = new Set(["success", "neutral", "skipped"]);
+            for (const contextName of requiredContexts) {
+              const status = latestStatusByContext.get(contextName);
+              if (!status) {
+                blockers.push({
+                  class: "globalStop",
+                  title: `required check missing on main: ${contextName}`,
+                  detail: `main ${mainSha} does not have a check run or commit status named ${contextName}.`
+                });
+                continue;
+              }
+              if (status.status !== "completed" || !passingConclusions.has(status.conclusion)) {
+                blockers.push({
+                  class: "globalStop",
+                  title: `required check not green on main: ${contextName}`,
+                  detail: `${status.kind} reported ${status.status}/${status.conclusion || "pending"} on ${mainSha}.`
+                });
+              }
+            }
+
+            const openPrs = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100
+            });
+
+            const openIssuesRaw = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100
+            });
+            const openIssues = openIssuesRaw.filter((issue) => !issue.pull_request);
+            const queueIssues = openIssues.filter((issue) =>
+              issue.labels.some((label) =>
+                ["agent:queued", "agent:claimed", "agent:running", "agent:merge-gate"].includes(label.name)
+              )
+            );
+
+            let dependabotOpen = null;
+            if (process.env.HAS_CODEX_HEALTH_TOKEN === "true") {
+              try {
+                const alerts = await github.request("GET /repos/{owner}/{repo}/dependabot/alerts", {
+                  owner,
+                  repo,
+                  state: "open",
+                  per_page: 100
+                });
+                dependabotOpen = alerts.data.length;
+                if (dependabotOpen > 0) {
+                  warnings.push({
+                    class: "advisory",
+                    title: "open Dependabot alerts",
+                    detail: `${dependabotOpen} open alert(s) need Security/DevOps triage.`
+                  });
+                }
+              } catch (error) {
+                warnings.push({
+                  class: "advisory",
+                  title: "Dependabot alert lookup unavailable",
+                  detail: `Dependabot lookup failed: ${error.status || "unknown"}.`
+                });
+              }
+            } else {
+              warnings.push({
+                class: "advisory",
+                title: "Dependabot alert lookup skipped",
+                detail: "Configure CODEX_HEALTH_TOKEN with Dependabot-alert read access for exact alert reconciliation."
+              });
+            }
+
+            const healthTitle = "[Codex Health] Cloud control-plane finding";
+            const healthIssues = openIssues.filter((issue) => issue.title === healthTitle);
+            const requiredLine = requiredContexts.length ? requiredContexts.join(", ") : "none reported";
+            const summary = [
+              "# Codex Cloud Meta Health",
+              "",
+              `Observed: ${now}`,
+              `Repository: ${owner}/${repo}`,
+              `main: ${mainSha}`,
+              `Required checks: ${requiredLine}`,
+              `Open PRs: ${openPrs.length}`,
+              `Open queued/running agent issues: ${queueIssues.length}`,
+              `Open Dependabot alerts: ${dependabotOpen === null ? "unavailable" : dependabotOpen}`,
+              "",
+              blockers.length
+                ? `## Blockers\n${blockers.map((item) => `- ${item.class}: ${item.title} (${item.detail})`).join("\n")}`
+                : "## Blockers\n- none",
+              "",
+              warnings.length
+                ? `## Warnings\n${warnings.map((item) => `- ${item.class}: ${item.title} (${item.detail})`).join("\n")}`
+                : "## Warnings\n- none",
+              "",
+              "## Routing",
+              blockers.length
+                ? "Meta Health has opened or refreshed the cloud health issue. Local build lanes should stay paused."
+                : "GitHub control-plane truth is healthy. R&D may prepare the next scored queue issue when no active queue item exists."
+            ].join("\n");
+
+            await core.summary.addRaw(summary).write();
+
+            if (!blockers.length) {
+              for (const issue of healthIssues) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: "closed",
+                  state_reason: "completed"
+                });
+              }
+              return;
+            }
+
+            const labels = ["agent:blocked", "blocker:global-stop"];
+            if (healthIssues.length) {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: healthIssues[0].number,
+                body: summary,
+                labels
+              });
+              for (const issue of healthIssues.slice(1)) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: "closed",
+                  state_reason: "not_planned"
+                });
+              }
+              core.setFailed("Codex Cloud Meta Health found a global blocker.");
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: healthTitle,
+              body: summary,
+              labels
+            });
+
+            core.setFailed("Codex Cloud Meta Health found a global blocker.");

--- a/.github/workflows/codex-cloud-research.yml
+++ b/.github/workflows/codex-cloud-research.yml
@@ -1,0 +1,242 @@
+name: Codex Cloud Research
+
+on:
+  schedule:
+    - cron: "7 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Run even when open PRs or active queue issues exist"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+concurrency:
+  group: codex-cloud-research
+  cancel-in-progress: true
+
+jobs:
+  research:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Gate cloud research
+        id: gate
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          result-encoding: string
+          script: |
+            const { owner, repo } = context.repo;
+            const force = context.payload.inputs?.force === "true" || context.payload.inputs?.force === true;
+            const openPrs = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100
+            });
+            const openIssuesRaw = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100
+            });
+            const activeQueueIssues = openIssuesRaw
+              .filter((issue) => !issue.pull_request)
+              .filter((issue) =>
+                issue.labels.some((label) =>
+                  ["agent:queued", "agent:claimed", "agent:running", "agent:merge-gate"].includes(label.name)
+                )
+              );
+
+            if (!force && (openPrs.length || activeQueueIssues.length)) {
+              return JSON.stringify({
+                run: false,
+                reason: `skipped: openPrs=${openPrs.length}, activeQueueIssues=${activeQueueIssues.length}`
+              });
+            }
+
+            return JSON.stringify({ run: true, reason: "cloud research eligible" });
+
+      - name: Checkout
+        if: contains(steps.gate.outputs.result, '"run":true')
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Prepare GitHub context
+        if: contains(steps.gate.outputs.result, '"run":true')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo "# Codex Cloud R&D Context"
+            echo
+            echo "Repository: $GITHUB_REPOSITORY"
+            echo "Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo
+            echo "## Open PRs"
+            gh pr list --json number,title,headRefName,isDraft,mergeStateStatus,reviewDecision,labels
+            echo
+            echo "## Open Issues"
+            gh issue list --state open --json number,title,labels
+            echo
+            echo "## Recent Runs"
+            gh run list --limit 10 --json databaseId,workflowName,headBranch,status,conclusion,event,createdAt
+          } > codex-cloud-context.md
+
+      - name: Report missing OPENAI_API_KEY
+        if: contains(steps.gate.outputs.result, '"run":true') && env.OPENAI_API_KEY == ''
+        run: |
+          {
+            echo "## Codex Cloud Research"
+            echo
+            echo "Skipped because repository secret OPENAI_API_KEY is not configured."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run Codex cloud research
+        id: run_codex
+        if: contains(steps.gate.outputs.result, '"run":true') && env.OPENAI_API_KEY != ''
+        uses: openai/codex-action@a26d2d4d8b78a694338b8e3715c3630254340b2c
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          sandbox: read-only
+          safety-strategy: drop-sudo
+          allow-users: onfire7777
+          output-file: codex-output.md
+          prompt: |
+            You are Stage 0 R&D for onfire7777/five-agent-dev-team.
+
+            Read the repository, .github/ISSUE_TEMPLATE/codex_queue_item.yml, codex-cloud-context.md, README.md, docs/**, and tests as needed.
+            Produce at most one GitHub issue-ready queue item.
+            Do not edit files, propose dependencies, merge, push, or mark acceptance complete.
+            Only propose work that maps to real product behavior and can run in codex-cloud, codex-action, or agentic-workflow.
+            If no non-overlapping product-spec-backed work scores at least 22/30, output exactly:
+            QUEUE_ITEM_READY: no
+
+            If a queue item is valid, output exactly this field set:
+            QUEUE_ITEM_READY: yes
+            Title: <short title>
+            Problem: <problem>
+            Hypothesis: <hypothesis>
+            Product-spec mapping: <specific README/docs/spec surface or acceptance behavior>
+            Expected files: <file globs>
+            Non-overlap check: <why it does not collide with open work>
+            Acceptance criteria: <bulleted criteria>
+            Verification commands: <commands>
+            Risk class: <low|medium|high>
+            Diff budget: <files and lines>
+            Rollback plan: <plan>
+            Lane assignment: <backend|frontend|quality|security|docs>
+            Execution target: <codex-cloud|codex-action|agentic-workflow>
+            Score: <22-30>/30
+
+      - name: Create or refresh queue issue
+        if: steps.run_codex.outputs.final-message != ''
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          CODEX_FINAL_MESSAGE: ${{ steps.run_codex.outputs.final-message }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const output = process.env.CODEX_FINAL_MESSAGE || "";
+            await core.summary.addRaw(`## Codex Cloud Research Output\n\n${output}`).write();
+
+            if (!/^QUEUE_ITEM_READY:\s*yes\s*$/im.test(output)) {
+              core.notice("Codex did not produce a queue item.");
+              return;
+            }
+
+            const requiredFields = [
+              "Title",
+              "Problem",
+              "Hypothesis",
+              "Product-spec mapping",
+              "Expected files",
+              "Non-overlap check",
+              "Acceptance criteria",
+              "Verification commands",
+              "Risk class",
+              "Diff budget",
+              "Rollback plan",
+              "Lane assignment",
+              "Execution target",
+              "Score"
+            ];
+            const missing = requiredFields.filter((field) => !new RegExp(`^${field}:`, "im").test(output));
+            if (missing.length) {
+              core.setFailed(`Codex output is missing required fields: ${missing.join(", ")}`);
+              return;
+            }
+
+            const scoreMatch = output.match(/^Score:\s*(\d+)\s*\/\s*30\s*$/im);
+            const score = scoreMatch ? Number(scoreMatch[1]) : 0;
+            if (score < 22 || score > 30) {
+              core.setFailed(`Codex output has invalid score: ${score || "missing"}`);
+              return;
+            }
+
+            const title = (output.match(/^Title:\s*(.+)$/im)?.[1] || "").trim();
+            const lane = (output.match(/^Lane assignment:\s*(backend|frontend|quality|security|docs)\s*$/im)?.[1] || "").trim();
+            const execution = (
+              output.match(/^Execution target:\s*(codex-cloud|codex-action|agentic-workflow)\s*$/im)?.[1] || ""
+            ).trim();
+
+            if (!title || !lane || !execution) {
+              core.setFailed("Codex output has invalid title, lane, or cloud execution target.");
+              return;
+            }
+
+            const issueTitle = title.startsWith("[Codex Queue]") ? title : `[Codex Queue] ${title}`;
+            const labels = ["agent:queued", `lane:${lane}`, `execution:${execution}`, "priority:p2"];
+            const body = [
+              "Created by Codex Cloud Research.",
+              "",
+              `Source run: ${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${context.runId}`,
+              "",
+              output
+            ].join("\n");
+
+            const openIssuesRaw = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100
+            });
+            const existing = openIssuesRaw.find((issue) => !issue.pull_request && issue.title === issueTitle);
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+                labels
+              });
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: issueTitle,
+              body,
+              labels
+            });
+
+      - name: Upload Codex research output
+        if: always() && contains(steps.gate.outputs.result, '"run":true')
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: codex-cloud-research
+          path: |
+            codex-output.md
+            codex-cloud-context.md
+          if-no-files-found: ignore

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -9,13 +9,16 @@ permissions:
   issues: write
   pull-requests: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: codex-pr-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   review:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:


### PR DESCRIPTION
Closes #24.

## Summary
- add scheduled/manual Codex Cloud Meta Health workflow for GitHub-side control-plane reconciliation
- add scheduled/manual Codex Cloud Research workflow that can create one validated issue-backed queue item when eligible
- harden Codex PR Review so closed PR label events do not fail after merge, and opt Codex workflows into Node 24 action runtime

## Verification
- node YAML parse for `.github/workflows`
- `npx prettier --check .github/workflows`
- `npm run diff:budget`
- `npm run logs:check`
- `npm run check`
- `coderabbit review --agent -t uncommitted -c AGENTS.md -c .coderabbit.yaml` raised 0 issues

## Setup note
`OPENAI_API_KEY` is not currently configured as a GitHub Actions secret. The deterministic cloud health workflow will run without it. The cloud R&D workflow is installed and will report a skipped run until that secret is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated JavaScript action execution environment across multiple workflows to Node.js 24.
  * Refined pull request review workflow to run only for open, non-draft PRs.

* **New Features**
  * Added an automated health-monitoring workflow that reports status, flags blockers, and manages related issues.
  * Added an automated research workflow that generates, validates, files research-driven issues, and uploads artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->