### PR TITLE
Restore Codex model fallback

### DIFF
--- a/.github/workflows/codex-ci-autofix.yml
+++ b/.github/workflows/codex-ci-autofix.yml
@@ -19,8 +19,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # gpt-5.2-codex currently fails in codex-action with an unsupported verbosity request.
-  CODEX_ACTION_MODEL: ${{ vars.CODEX_ACTION_MODEL || 'gpt-5.2' }}
+  CODEX_ACTION_MODEL: ${{ vars.CODEX_ACTION_MODEL || 'gpt-5.2-codex' }}
   CODEX_ACTION_EFFORT: ${{ vars.CODEX_ACTION_EFFORT || 'xhigh' }}
 
 concurrency:

--- a/.github/workflows/codex-cloud-research.yml
+++ b/.github/workflows/codex-cloud-research.yml
@@ -19,8 +19,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # gpt-5.2-codex currently fails in codex-action with an unsupported verbosity request.
-  CODEX_ACTION_MODEL: ${{ vars.CODEX_ACTION_MODEL || 'gpt-5.2' }}
+  CODEX_ACTION_MODEL: ${{ vars.CODEX_ACTION_MODEL || 'gpt-5.2-codex' }}
   CODEX_ACTION_EFFORT: ${{ vars.CODEX_ACTION_EFFORT || 'xhigh' }}
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -11,8 +11,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # gpt-5.2-codex currently fails in codex-action with an unsupported verbosity request.
-  CODEX_ACTION_MODEL: ${{ vars.CODEX_ACTION_MODEL || 'gpt-5.2' }}
+  CODEX_ACTION_MODEL: ${{ vars.CODEX_ACTION_MODEL || 'gpt-5.2-codex' }}
   CODEX_ACTION_EFFORT: ${{ vars.CODEX_ACTION_EFFORT || 'xhigh' }}
 
 concurrency:


### PR DESCRIPTION
## Summary
- restore Codex Action fallback model to gpt-5.2-codex now that model_verbosity is configured
- keep xhigh reasoning and repo-variable override policy intact

## Validation
- git diff --check
- Codex Cloud Research run 25204499350 succeeded with CODEX_ACTION_MODEL=gpt-5.2-codex and CODEX_ACTION_EFFORT=xhigh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI model configuration across CI/CD workflows for code review and automation tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->