### PR TITLE
Restore Codex action fallback to codex model

### DIFF
--- a/.github/workflows/codex-ci-autofix.yml
+++ b/.github/workflows/codex-ci-autofix.yml
@@ -19,8 +19,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # gpt-5.2-codex currently fails in codex-action with an unsupported verbosity request.
-  CODEX_ACTION_MODEL: ${{ vars.CODEX_ACTION_MODEL || 'gpt-5.2' }}
+  CODEX_ACTION_MODEL: ${{ vars.CODEX_ACTION_MODEL || 'gpt-5.2-codex' }}
   CODEX_ACTION_EFFORT: ${{ vars.CODEX_ACTION_EFFORT || 'xhigh' }}
 
 concurrency:

--- a/.github/workflows/codex-cloud-research.yml
+++ b/.github/workflows/codex-cloud-research.yml
@@ -19,8 +19,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # gpt-5.2-codex currently fails in codex-action with an unsupported verbosity request.
-  CODEX_ACTION_MODEL: ${{ vars.CODEX_ACTION_MODEL || 'gpt-5.2' }}
+  CODEX_ACTION_MODEL: ${{ vars.CODEX_ACTION_MODEL || 'gpt-5.2-codex' }}
   CODEX_ACTION_EFFORT: ${{ vars.CODEX_ACTION_EFFORT || 'xhigh' }}
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -11,8 +11,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # gpt-5.2-codex currently fails in codex-action with an unsupported verbosity request.
-  CODEX_ACTION_MODEL: ${{ vars.CODEX_ACTION_MODEL || 'gpt-5.2' }}
+  CODEX_ACTION_MODEL: ${{ vars.CODEX_ACTION_MODEL || 'gpt-5.2-codex' }}
   CODEX_ACTION_EFFORT: ${{ vars.CODEX_ACTION_EFFORT || 'xhigh' }}
 
 concurrency:


### PR DESCRIPTION
## Summary
- restore Codex Action fallback model to gpt-5.2-codex now that model_verbosity=medium is configured
- keep CODEX_ACTION_MODEL and CODEX_ACTION_EFFORT repo-variable overrides
- keep xhigh reasoning defaults

## Evidence
- PR #28 ran this same commit through CI, CodeQL, Codex PR Review, and CodeRabbit successfully
- Codex Cloud Research run 25204499350 succeeded with CODEX_ACTION_MODEL=gpt-5.2-codex and CODEX_ACTION_EFFORT=xhigh

## Validation
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub workflows to use an improved model configuration for automated code review and analysis processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->