### PR TITLE
Align opportunity scan payloads with scan-run schema

### DIFF
--- a/apps/controller/src/index.ts
+++ b/apps/controller/src/index.ts
@@ -25,6 +25,7 @@ import {
   EmergencyControlRequestSchema,
   ProjectCapabilityStatusSchema,
   ProjectConnectionInputSchema,
+  OpportunityScanRunSchema,
   WorkItemStateSchema,
   loadTargetRepoConfig,
   targetRepoConfigFromProjectConnection,
@@ -503,16 +504,24 @@ app.get("/api/projects/:projectId/opportunities", async (req, res, next) => {
 app.post("/api/projects/:projectId/opportunities/scan", async (req, res, next) => {
   try {
     const scope = await requireScopeForProjectId(req.params.projectId);
-    const opportunity = await scanLeanOpportunity(scope);
+    const startedAt = new Date().toISOString();
+    const result = await scanLeanOpportunity(scope);
     const opportunities = await store.listOpportunities(scope);
+    const scan = OpportunityScanRunSchema.parse(
+      await store.upsertOpportunityScanRun(scope, {
+        status: "complete",
+        sources: result.sources,
+        candidatesCreated: result.created ? 1 : 0,
+        summary: result.created
+          ? `Created opportunity candidate ${result.opportunity.id}.`
+          : `Reused existing opportunity candidate ${result.opportunity.id}.`,
+        startedAt,
+        completedAt: new Date().toISOString()
+      })
+    );
     res.status(201).json({
-      scan: {
-        projectId: scope.projectId,
-        repo: scope.repo,
-        status: "completed",
-        candidateCount: opportunities.length
-      },
-      opportunity: mapOpportunityForUi(opportunity),
+      scan,
+      opportunity: mapOpportunityForUi(result.opportunity),
       opportunities: opportunities.map(mapOpportunityForUi)
     });
   } catch (error) {
@@ -1517,11 +1526,13 @@ async function decideProposalById(proposalId: string, input: z.infer<typeof Prop
   return { proposal: mapProposalForUi(updated), workItemId: proposal.workItemId, nextState, signaled };
 }
 
-async function scanLeanOpportunity(scope: StrictProjectScope): Promise<Opportunity> {
+async function scanLeanOpportunity(
+  scope: StrictProjectScope
+): Promise<{ opportunity: Opportunity; created: boolean; sources: Array<"human_direction" | "repo_memory"> }> {
   const existing = (await store.listOpportunities(scope)).find(
     (item) => item.status !== "accepted" && item.status !== "rejected" && item.tags.includes("autonomous-scan")
   );
-  if (existing) return existing;
+  if (existing) return { opportunity: existing, created: false, sources: ["repo_memory"] };
 
   const direction = await store.getDirection(scope);
   const title = direction?.summary
@@ -1530,7 +1541,7 @@ async function scanLeanOpportunity(scope: StrictProjectScope): Promise<Opportuni
   const summary = direction?.summary
     ? `Use the saved project direction as steering input, then prefer hardening, debugging, testing, performance, and maintainability work before proposing feature expansion. Direction: ${direction.summary}`
     : "No user work is blocking, so run a lean autonomous hardening pass: inspect failed checks, TODO/FIXME markers, weak tests, recent blockers, release-gate gaps, and repo memory before proposing the next safest improvement.";
-  return store.upsertOpportunity(scope, {
+  const opportunity = await store.upsertOpportunity(scope, {
     title,
     summary,
     source: direction ? "operator" : "agent",
@@ -1538,6 +1549,7 @@ async function scanLeanOpportunity(scope: StrictProjectScope): Promise<Opportuni
     status: "new",
     tags: ["autonomous-scan", "hardening", "deduped"]
   });
+  return { opportunity, created: true, sources: [direction ? "human_direction" : "repo_memory"] };
 }
 
 async function decideWorkItemProposal(workItemId: string, decision: "accept" | "revise" | "reject", body: unknown) {

--- a/apps/controller/src/index.ts
+++ b/apps/controller/src/index.ts
@@ -502,20 +502,31 @@ app.get("/api/projects/:projectId/opportunities", async (req, res, next) => {
 });
 
 app.post("/api/projects/:projectId/opportunities/scan", async (req, res, next) => {
+  let scope: StrictProjectScope | undefined;
+  let scanId: string | undefined;
   try {
-    const scope = await requireScopeForProjectId(req.params.projectId);
+    scope = await requireScopeForProjectId(req.params.projectId);
     const startedAt = new Date().toISOString();
+    const runningScan = await store.upsertOpportunityScanRun(scope, {
+      status: "running",
+      sources: [],
+      candidatesCreated: 0,
+      summary: "Opportunity scan started.",
+      startedAt
+    });
+    scanId = runningScan.id;
     const result = await scanLeanOpportunity(scope);
     const opportunities = await store.listOpportunities(scope);
     const scan = OpportunityScanRunSchema.parse(
       await store.upsertOpportunityScanRun(scope, {
+        id: scanId,
         status: "complete",
         sources: result.sources,
         candidatesCreated: result.created ? 1 : 0,
         summary: result.created
           ? `Created opportunity candidate ${result.opportunity.id}.`
           : `Reused existing opportunity candidate ${result.opportunity.id}.`,
-        startedAt,
+        startedAt: runningScan.startedAt,
         completedAt: new Date().toISOString()
       })
     );
@@ -525,6 +536,16 @@ app.post("/api/projects/:projectId/opportunities/scan", async (req, res, next) =
       opportunities: opportunities.map(mapOpportunityForUi)
     });
   } catch (error) {
+    if (scope && scanId) {
+      await store
+        .upsertOpportunityScanRun(scope, {
+          id: scanId,
+          status: "failed",
+          summary: "Opportunity scan failed before completion.",
+          completedAt: new Date().toISOString()
+        })
+        .catch(() => undefined);
+    }
     next(error);
   }
 });
@@ -1529,12 +1550,16 @@ async function decideProposalById(proposalId: string, input: z.infer<typeof Prop
 async function scanLeanOpportunity(
   scope: StrictProjectScope
 ): Promise<{ opportunity: Opportunity; created: boolean; sources: Array<"human_direction" | "repo_memory"> }> {
-  const existing = (await store.listOpportunities(scope)).find(
-    (item) => item.status !== "accepted" && item.status !== "rejected" && item.tags.includes("autonomous-scan")
-  );
-  if (existing) return { opportunity: existing, created: false, sources: ["repo_memory"] };
-
   const direction = await store.getDirection(scope);
+  const sources: Array<"human_direction" | "repo_memory"> = [direction ? "human_direction" : "repo_memory"];
+  const opportunities = await store.listOpportunities(scope);
+  const existing =
+    opportunities.find((item) => item.id === "autonomous-scan") ||
+    opportunities.find(
+      (item) => item.status !== "accepted" && item.status !== "rejected" && item.tags.includes("autonomous-scan")
+    );
+  if (existing) return { opportunity: existing, created: false, sources };
+
   const title = direction?.summary
     ? `Act on project direction: ${direction.summary.slice(0, 80)}`
     : "Strengthen repo reliability, tests, and release readiness";
@@ -1542,6 +1567,7 @@ async function scanLeanOpportunity(
     ? `Use the saved project direction as steering input, then prefer hardening, debugging, testing, performance, and maintainability work before proposing feature expansion. Direction: ${direction.summary}`
     : "No user work is blocking, so run a lean autonomous hardening pass: inspect failed checks, TODO/FIXME markers, weak tests, recent blockers, release-gate gaps, and repo memory before proposing the next safest improvement.";
   const opportunity = await store.upsertOpportunity(scope, {
+    id: "autonomous-scan",
     title,
     summary,
     source: direction ? "operator" : "agent",
@@ -1549,7 +1575,7 @@ async function scanLeanOpportunity(
     status: "new",
     tags: ["autonomous-scan", "hardening", "deduped"]
   });
-  return { opportunity, created: true, sources: [direction ? "human_direction" : "repo_memory"] };
+  return { opportunity, created: true, sources };
 }
 
 async function decideWorkItemProposal(workItemId: string, decision: "accept" | "revise" | "reject", body: unknown) {

--- a/apps/controller/src/store.ts
+++ b/apps/controller/src/store.ts
@@ -11,6 +11,7 @@ import {
   ProjectConnectionInputSchema,
   ProjectConnectionSchema,
   ProjectTeamStatusSchema,
+  OpportunityScanRunSchema,
   repoKeyForConfig,
   StageArtifactSchema,
   MemoryRecordSchema,
@@ -23,6 +24,7 @@ import {
   type ProjectConnection,
   type ProjectConnectionInput,
   type ProjectTeamStatus,
+  type OpportunityScanRun,
   type StageArtifact,
   type WorkItem,
   type WorkItemState
@@ -150,6 +152,14 @@ export type Opportunity = StrictProjectScope & {
   updatedAt: string;
 };
 
+export type OpportunityScanRunInput = Pick<OpportunityScanRun, "summary"> &
+  Partial<
+    Pick<
+      OpportunityScanRun,
+      "id" | "status" | "sources" | "repoSha" | "memoryVersion" | "candidatesCreated" | "startedAt" | "completedAt"
+    >
+  >;
+
 export type ProposalOption = {
   title: string;
   summary: string;
@@ -243,6 +253,8 @@ export interface ControllerStore {
   upsertDirection(scope: StrictProjectScope, input: DirectionInput): Promise<Direction>;
   listOpportunities(scope: StrictProjectScope): Promise<Opportunity[]>;
   upsertOpportunity(scope: StrictProjectScope, input: OpportunityInput): Promise<Opportunity>;
+  listOpportunityScanRuns(scope: StrictProjectScope): Promise<OpportunityScanRun[]>;
+  upsertOpportunityScanRun(scope: StrictProjectScope, input: OpportunityScanRunInput): Promise<OpportunityScanRun>;
   listProposals(scope: StrictProjectScope): Promise<Proposal[]>;
   upsertProposal(scope: StrictProjectScope, input: ProposalInput): Promise<Proposal>;
   decideProposal(scope: StrictProjectScope, proposalId: string, input: ProposalDecisionInput): Promise<Proposal>;
@@ -261,6 +273,7 @@ export class MemoryStore implements ControllerStore {
   private loopRuns: LoopRun[] = [];
   private directions: Direction[] = [];
   private opportunities: Opportunity[] = [];
+  private opportunityScanRuns: OpportunityScanRun[] = [];
   private proposals: Proposal[] = [];
   private events: AgentEvent[] = [];
   private nextEventSequence = 1;
@@ -551,6 +564,39 @@ export class MemoryStore implements ControllerStore {
     return opportunity;
   }
 
+  async listOpportunityScanRuns(scope: StrictProjectScope): Promise<OpportunityScanRun[]> {
+    await this.assertProjectScope(scope);
+    return this.opportunityScanRuns
+      .filter((scan) => sameScope(scan, scope))
+      .sort((a, b) => Date.parse(b.completedAt || b.startedAt) - Date.parse(a.completedAt || a.startedAt));
+  }
+
+  async upsertOpportunityScanRun(
+    scope: StrictProjectScope,
+    input: OpportunityScanRunInput
+  ): Promise<OpportunityScanRun> {
+    await this.assertProjectScope(scope);
+    const now = nowIso();
+    const existing = input.id
+      ? this.opportunityScanRuns.find((scan) => scan.id === input.id && sameScope(scan, scope))
+      : undefined;
+    const resolvedStatus = input.status ?? existing?.status ?? "complete";
+    const scan = OpportunityScanRunSchema.parse({
+      id: input.id ?? createRecordId("scan"),
+      ...scope,
+      status: resolvedStatus,
+      sources: input.sources ?? existing?.sources ?? [],
+      repoSha: input.repoSha ?? existing?.repoSha,
+      memoryVersion: input.memoryVersion ?? existing?.memoryVersion,
+      candidatesCreated: input.candidatesCreated ?? existing?.candidatesCreated ?? 0,
+      summary: input.summary,
+      startedAt: input.startedAt ?? existing?.startedAt ?? now,
+      completedAt: input.completedAt ?? existing?.completedAt ?? (resolvedStatus === "running" ? undefined : now)
+    });
+    this.opportunityScanRuns = upsertByScopedId(this.opportunityScanRuns, scan);
+    return scan;
+  }
+
   async listProposals(scope: StrictProjectScope): Promise<Proposal[]> {
     await this.assertProjectScope(scope);
     return this.proposals
@@ -756,6 +802,17 @@ export class PostgresStore extends MemoryStore {
         payload jsonb not null,
         updated_at timestamptz not null default now()
       );
+      create table if not exists opportunity_scan_runs (
+        id text primary key,
+        project_id text not null,
+        repo text not null,
+        payload jsonb not null,
+        started_at timestamptz not null,
+        completed_at timestamptz,
+        updated_at timestamptz not null default now()
+      );
+      create index if not exists opportunity_scan_runs_project_repo_recency_idx
+        on opportunity_scan_runs (project_id, repo, (coalesce(completed_at, started_at)) desc);
       create table if not exists proposals (
         id text primary key,
         project_id text not null,
@@ -1088,6 +1145,60 @@ export class PostgresStore extends MemoryStore {
       [scopedDbId(scope, opportunity.id), opportunity.projectId, opportunity.repo, opportunity, opportunity.updatedAt]
     );
     return opportunity;
+  }
+
+  override async listOpportunityScanRuns(scope: StrictProjectScope): Promise<OpportunityScanRun[]> {
+    await this.assertProjectScope(scope);
+    const result = await this.pool.query(
+      `select payload from opportunity_scan_runs
+       where project_id = $1 and repo = $2
+       order by coalesce(completed_at, started_at) desc`,
+      [scope.projectId, scope.repo]
+    );
+    return result.rows.map((row) => OpportunityScanRunSchema.parse(row.payload));
+  }
+
+  override async upsertOpportunityScanRun(
+    scope: StrictProjectScope,
+    input: OpportunityScanRunInput
+  ): Promise<OpportunityScanRun> {
+    const existing = input.id ? await this.getStoredOpportunityScanRun(scope, input.id) : null;
+    const mergedInput = existing
+      ? {
+          id: input.id ?? existing.id,
+          status: input.status ?? existing.status,
+          sources: input.sources ?? existing.sources,
+          repoSha: input.repoSha ?? existing.repoSha,
+          memoryVersion: input.memoryVersion ?? existing.memoryVersion,
+          candidatesCreated: input.candidatesCreated ?? existing.candidatesCreated,
+          summary: input.summary,
+          startedAt: input.startedAt ?? existing.startedAt,
+          completedAt: input.completedAt ?? existing.completedAt
+        }
+      : input;
+    const scan = await super.upsertOpportunityScanRun(scope, mergedInput);
+    if (existing && sameOpportunityScanRun(scan, existing)) return existing;
+    await this.pool.query(
+      `insert into opportunity_scan_runs (id, project_id, repo, payload, started_at, completed_at, updated_at)
+       values ($1, $2, $3, $4, $5, $6, now())
+       on conflict (id) do update set
+         payload = excluded.payload,
+         project_id = excluded.project_id,
+         repo = excluded.repo,
+         started_at = excluded.started_at,
+         completed_at = excluded.completed_at,
+         updated_at = excluded.updated_at`,
+      [scopedDbId(scope, scan.id), scan.projectId, scan.repo, scan, scan.startedAt, scan.completedAt || null]
+    );
+    return scan;
+  }
+
+  private async getStoredOpportunityScanRun(scope: StrictProjectScope, id: string): Promise<OpportunityScanRun | null> {
+    const result = await this.pool.query(
+      "select payload from opportunity_scan_runs where id = $1 and project_id = $2 and repo = $3",
+      [scopedDbId(scope, id), scope.projectId, scope.repo]
+    );
+    return result.rows[0] ? OpportunityScanRunSchema.parse(result.rows[0].payload) : null;
   }
 
   override async listProposals(scope: StrictProjectScope): Promise<Proposal[]> {
@@ -1518,6 +1629,22 @@ function sameScope(value: StrictProjectScope, scope: StrictProjectScope): boolea
 
 function upsertByScopedId<T extends StrictProjectScope & { id: string }>(items: T[], item: T): T[] {
   return [...items.filter((existing) => existing.id !== item.id || !sameScope(existing, item)), item];
+}
+
+function sameOpportunityScanRun(left: OpportunityScanRun, right: OpportunityScanRun): boolean {
+  return (
+    left.id === right.id &&
+    left.projectId === right.projectId &&
+    left.repo === right.repo &&
+    left.status === right.status &&
+    JSON.stringify(left.sources) === JSON.stringify(right.sources) &&
+    left.repoSha === right.repoSha &&
+    left.memoryVersion === right.memoryVersion &&
+    left.candidatesCreated === right.candidatesCreated &&
+    left.summary === right.summary &&
+    left.startedAt === right.startedAt &&
+    left.completedAt === right.completedAt
+  );
 }
 
 function loopStatusForProposalDecision(decision: ProposalDecision["decision"]): LoopRun["status"] {

--- a/apps/controller/src/store.ts
+++ b/apps/controller/src/store.ts
@@ -729,6 +729,10 @@ export class PostgresStore extends MemoryStore {
     this.pool = new pg.Pool({ connectionString });
   }
 
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+
   override async init(): Promise<void> {
     await this.pool.query(`
       create table if not exists work_items (

--- a/tests/release-activities.test.ts
+++ b/tests/release-activities.test.ts
@@ -8,6 +8,7 @@ import type {
   Direction,
   LoopRun,
   Opportunity,
+  OpportunityScanRunInput,
   Proposal,
   StrictProjectScope,
   TeamBusMessage
@@ -340,6 +341,24 @@ function fakeStore(): FakeStore {
         createdAt: now,
         updatedAt: now
       } satisfies Opportunity;
+    },
+    async listOpportunityScanRuns() {
+      return [];
+    },
+    async upsertOpportunityScanRun(scope: StrictProjectScope, input: OpportunityScanRunInput) {
+      const now = new Date().toISOString();
+      return {
+        id: input.id || "scan-fake",
+        ...scope,
+        status: input.status || "complete",
+        sources: input.sources || [],
+        repoSha: input.repoSha,
+        memoryVersion: input.memoryVersion,
+        candidatesCreated: input.candidatesCreated || 0,
+        summary: input.summary,
+        startedAt: input.startedAt || now,
+        completedAt: input.completedAt || now
+      };
     },
     async listProposals() {
       return [];

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { MemoryStore } from "../apps/controller/src/store";
-import { StageArtifactSchema, type MemoryRecord, type StageArtifact } from "../packages/shared/src";
+import {
+  OpportunityScanRunSchema,
+  StageArtifactSchema,
+  type MemoryRecord,
+  type StageArtifact
+} from "../packages/shared/src";
 
 describe("controller store workflow claims", () => {
   it("prevents duplicate workflow claims for the same item", async () => {
@@ -122,6 +127,58 @@ describe("controller store workflow claims", () => {
         projectId: "missing"
       })
     ).rejects.toThrow(/Connected project was not found/);
+  });
+
+  it("persists schema-conformant opportunity scan runs newest-first", async () => {
+    const store = new MemoryStore();
+    await store.upsertProjectConnection({
+      repoOwner: "owner",
+      repoName: "repo-a",
+      localPath: "C:/repos/a",
+      active: true
+    });
+    const scope = { projectId: "owner-repo-a", repo: "owner/repo-a" };
+
+    const older = await store.upsertOpportunityScanRun(scope, {
+      sources: ["repo_memory"],
+      candidatesCreated: 1,
+      summary: "Older scan found one candidate.",
+      startedAt: "2026-05-01T00:00:00.000Z",
+      completedAt: "2026-05-01T00:00:01.000Z"
+    });
+    const newer = await store.upsertOpportunityScanRun(scope, {
+      sources: ["human_direction"],
+      candidatesCreated: 0,
+      summary: "Newer scan reused an existing candidate.",
+      startedAt: "2026-05-01T01:00:00.000Z",
+      completedAt: "2026-05-01T01:00:01.000Z"
+    });
+    const running = await store.upsertOpportunityScanRun(scope, {
+      status: "running",
+      sources: ["repo_memory"],
+      summary: "Running scan is not complete yet.",
+      startedAt: "2026-05-01T02:00:00.000Z"
+    });
+    const updatedOlder = await store.upsertOpportunityScanRun(scope, {
+      id: older.id,
+      summary: "Older scan summary updated."
+    });
+
+    expect(OpportunityScanRunSchema.parse(newer)).toMatchObject({
+      projectId: scope.projectId,
+      repo: scope.repo,
+      status: "complete",
+      sources: ["human_direction"],
+      candidatesCreated: 0
+    });
+    expect(running.completedAt).toBeUndefined();
+    expect(updatedOlder).toMatchObject({
+      sources: ["repo_memory"],
+      candidatesCreated: 1,
+      startedAt: "2026-05-01T00:00:00.000Z",
+      completedAt: "2026-05-01T00:00:01.000Z"
+    });
+    await expect(store.listOpportunityScanRuns(scope)).resolves.toEqual([running, newer, updatedOlder]);
   });
 
   it("scopes repo and global memory when listing memories for a work item", async () => {

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,11 +1,71 @@
 import { describe, expect, it } from "vitest";
-import { MemoryStore } from "../apps/controller/src/store";
+import {
+  MemoryStore,
+  PostgresStore,
+  type ControllerStore,
+  type StrictProjectScope
+} from "../apps/controller/src/store";
 import {
   OpportunityScanRunSchema,
   StageArtifactSchema,
   type MemoryRecord,
   type StageArtifact
 } from "../packages/shared/src";
+
+async function seedScanScope(store: ControllerStore, repoName: string): Promise<StrictProjectScope> {
+  await store.upsertProjectConnection({
+    repoOwner: "owner",
+    repoName,
+    localPath: `C:/repos/${repoName}`,
+    active: true
+  });
+  return { projectId: `owner-${repoName}`, repo: `owner/${repoName}` };
+}
+
+async function expectOpportunityScanRunsNewestFirst(store: ControllerStore, repoName = "repo-a") {
+  const scope = await seedScanScope(store, repoName);
+
+  const older = await store.upsertOpportunityScanRun(scope, {
+    sources: ["repo_memory"],
+    candidatesCreated: 1,
+    summary: "Older scan found one candidate.",
+    startedAt: "2026-05-01T00:00:00.000Z",
+    completedAt: "2026-05-01T00:00:01.000Z"
+  });
+  const newer = await store.upsertOpportunityScanRun(scope, {
+    sources: ["human_direction"],
+    candidatesCreated: 0,
+    summary: "Newer scan reused an existing candidate.",
+    startedAt: "2026-05-01T01:00:00.000Z",
+    completedAt: "2026-05-01T01:00:01.000Z"
+  });
+  const running = await store.upsertOpportunityScanRun(scope, {
+    status: "running",
+    sources: ["repo_memory"],
+    summary: "Running scan is not complete yet.",
+    startedAt: "2026-05-01T02:00:00.000Z"
+  });
+  const updatedOlder = await store.upsertOpportunityScanRun(scope, {
+    id: older.id,
+    summary: "Older scan summary updated."
+  });
+
+  expect(OpportunityScanRunSchema.parse(newer)).toMatchObject({
+    projectId: scope.projectId,
+    repo: scope.repo,
+    status: "complete",
+    sources: ["human_direction"],
+    candidatesCreated: 0
+  });
+  expect(running.completedAt).toBeUndefined();
+  expect(updatedOlder).toMatchObject({
+    sources: ["repo_memory"],
+    candidatesCreated: 1,
+    startedAt: "2026-05-01T00:00:00.000Z",
+    completedAt: "2026-05-01T00:00:01.000Z"
+  });
+  await expect(store.listOpportunityScanRuns(scope)).resolves.toEqual([running, newer, updatedOlder]);
+}
 
 describe("controller store workflow claims", () => {
   it("prevents duplicate workflow claims for the same item", async () => {
@@ -131,55 +191,23 @@ describe("controller store workflow claims", () => {
 
   it("persists schema-conformant opportunity scan runs newest-first", async () => {
     const store = new MemoryStore();
-    await store.upsertProjectConnection({
-      repoOwner: "owner",
-      repoName: "repo-a",
-      localPath: "C:/repos/a",
-      active: true
-    });
-    const scope = { projectId: "owner-repo-a", repo: "owner/repo-a" };
-
-    const older = await store.upsertOpportunityScanRun(scope, {
-      sources: ["repo_memory"],
-      candidatesCreated: 1,
-      summary: "Older scan found one candidate.",
-      startedAt: "2026-05-01T00:00:00.000Z",
-      completedAt: "2026-05-01T00:00:01.000Z"
-    });
-    const newer = await store.upsertOpportunityScanRun(scope, {
-      sources: ["human_direction"],
-      candidatesCreated: 0,
-      summary: "Newer scan reused an existing candidate.",
-      startedAt: "2026-05-01T01:00:00.000Z",
-      completedAt: "2026-05-01T01:00:01.000Z"
-    });
-    const running = await store.upsertOpportunityScanRun(scope, {
-      status: "running",
-      sources: ["repo_memory"],
-      summary: "Running scan is not complete yet.",
-      startedAt: "2026-05-01T02:00:00.000Z"
-    });
-    const updatedOlder = await store.upsertOpportunityScanRun(scope, {
-      id: older.id,
-      summary: "Older scan summary updated."
-    });
-
-    expect(OpportunityScanRunSchema.parse(newer)).toMatchObject({
-      projectId: scope.projectId,
-      repo: scope.repo,
-      status: "complete",
-      sources: ["human_direction"],
-      candidatesCreated: 0
-    });
-    expect(running.completedAt).toBeUndefined();
-    expect(updatedOlder).toMatchObject({
-      sources: ["repo_memory"],
-      candidatesCreated: 1,
-      startedAt: "2026-05-01T00:00:00.000Z",
-      completedAt: "2026-05-01T00:00:01.000Z"
-    });
-    await expect(store.listOpportunityScanRuns(scope)).resolves.toEqual([running, newer, updatedOlder]);
+    await expectOpportunityScanRunsNewestFirst(store);
   });
+
+  it.skipIf(!process.env.POSTGRES_TEST_DATABASE_URL)(
+    "persists schema-conformant opportunity scan runs newest-first in Postgres",
+    async () => {
+      const connectionString = process.env.POSTGRES_TEST_DATABASE_URL;
+      if (!connectionString) throw new Error("POSTGRES_TEST_DATABASE_URL is required for this test.");
+      const store = new PostgresStore(connectionString);
+      try {
+        await store.init();
+        await expectOpportunityScanRunsNewestFirst(store, `repo-scan-runs-${process.pid}-${Date.now()}`);
+      } finally {
+        await store.close();
+      }
+    }
+  );
 
   it("scopes repo and global memory when listing memories for a work item", async () => {
     const store = new MemoryStore();


### PR DESCRIPTION
## Summary
- Persist opportunity scan runs in memory and Postgres stores.
- Return a schema-conformant `scan` from `POST /api/projects/:projectId/opportunities/scan`.
- Add regression coverage for scan-run schema validity and newest-first listing.

## Scope
Backend/Core lane for issue #27. No frontend or dependency changes.

## Validation
- npm test -- tests/store.test.ts
- npm run typecheck
- npm run lint
- npm run format:check
- npm run diff:budget
- npm run check

## Acceptance evidence
| Criterion | Evidence | Status |
|---|---|---|
| Scan payload parses with `OpportunityScanRunSchema` | Route parses persisted scan before response; store test parses persisted scan | Pass |
| Scan runs persist newest-first | `MemoryStore.listOpportunityScanRuns` test covers ordering | Pass |
| Targeted regression coverage | `tests/store.test.ts` added scan-run persistence test | Pass |

## Risk
Medium. Adds a new Postgres table and memory-store collection for scan-run evidence.

## Rollback
Revert this PR. The new table can be ignored or dropped if needed.

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scan endpoint now persists scan-run records and returns them with status (running/complete/failed), start/end timestamps, source tags, candidate-created flag/count, and human-readable summaries.
  * Backend supports listing and upserting scan-run records with newest-first recency ordering.

* **Tests**
  * Added tests and test-mock coverage validating persistence, ordering (newest-first), running vs completed status, and upsert behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->