### PR TITLE
Keep Codex cloud artifacts out of verification

### DIFF
--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -566,5 +566,8 @@ jobs:
             ${{ runner.temp }}/codex-cloud-artifacts/codex-output.md
             ${{ runner.temp }}/codex-cloud-artifacts/codex-stage-context.md
             ${{ runner.temp }}/codex-cloud-artifacts/codex-target.json
+            codex-output.md
+            codex-stage-context.md
+            codex-target.json
             pr-body.md
           if-no-files-found: ignore

--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -370,6 +370,13 @@ jobs:
         if: steps.gate.outputs.should_run == 'true' && steps.gate.outputs.target_kind == 'issue'
         shell: bash
         run: |
+          mkdir -p "$RUNNER_TEMP/codex-cloud-artifacts"
+          for file in codex-output.md codex-stage-context.md codex-target.json; do
+            if [ -f "$file" ]; then
+              cp "$file" "$RUNNER_TEMP/codex-cloud-artifacts/$file"
+              rm "$file"
+            fi
+          done
           if git diff --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
@@ -556,8 +563,8 @@ jobs:
         with:
           name: codex-cloud-${{ steps.gate.outputs.stage || 'stage' }}
           path: |
-            codex-output.md
-            codex-stage-context.md
-            codex-target.json
+            ${{ runner.temp }}/codex-cloud-artifacts/codex-output.md
+            ${{ runner.temp }}/codex-cloud-artifacts/codex-stage-context.md
+            ${{ runner.temp }}/codex-cloud-artifacts/codex-target.json
             pr-body.md
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Moves Codex cloud build context/output artifacts out of the repository workspace before diff detection and verification so generated metadata does not get formatted, committed, or block PR publication.

## Validation

- npm run check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- npm run automation:verify-paused
- workflow YAML parse
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline improved to persist generated output during cleanup and ensure those build artifacts are uploaded and remain available after workspace cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->