### PR TITLE
Seed Codex state for cloud log validation

### DIFF
--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -295,6 +295,13 @@ jobs:
         if: steps.gate.outputs.should_run == 'true' && steps.gate.outputs.target_kind == 'issue'
         run: npm ci
 
+      - name: Seed cloud Codex state surface
+        if: steps.gate.outputs.should_run == 'true' && steps.gate.outputs.target_kind == 'issue'
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.codex/state/runs"
+          touch "$HOME/.codex/state/five-agent-dev-team-ledger.ndjson"
+
       - name: Prepare stage context
         if: steps.gate.outputs.should_run == 'true' && steps.gate.outputs.target_kind == 'issue'
         env:


### PR DESCRIPTION
## Summary

Seeds the minimal Codex state surface in GitHub runners before cloud build execution so 
pm run logs:check can validate cleanly without requiring private local state files.

## Validation

- npm run check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- workflow YAML parse
- git diff --check
- coderabbit review --agent -t uncommitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline initialization to ensure proper state directory setup for automated issue-targeted workflow executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->