### PR TITLE
Codex Cloud Backend/Core: Enforce absolute localPath for project connections

### DIFF
--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -55,6 +55,14 @@ function defaultArtifactId(): string {
   return globalThis.crypto?.randomUUID?.() || `artifact-${Date.now().toString(36)}`;
 }
 
+const ABSOLUTE_LOCAL_PATH_REGEX = /^(?:\/|[A-Za-z]:[\\/])/;
+const AbsoluteLocalPathSchema = z
+  .string()
+  .min(1)
+  .refine((value) => ABSOLUTE_LOCAL_PATH_REGEX.test(value), {
+    message: "Local path must be an absolute path."
+  });
+
 const AcceptanceCriterionSchema = z.object({
   id: z.string().min(1),
   text: z.string().min(1),
@@ -676,7 +684,7 @@ export const ProjectConnectionInputSchema = z.object({
   repoOwner: z.string().min(1),
   repoName: z.string().min(1),
   defaultBranch: z.string().min(1).default("main"),
-  localPath: z.string().min(1),
+  localPath: AbsoluteLocalPathSchema,
   githubUrl: z.string().url().optional(),
   webResearchEnabled: z.boolean().default(true),
   githubMcpEnabled: z.boolean().default(true),
@@ -970,7 +978,7 @@ export const TargetRepoConfigSchema = z.object({
     owner: z.string().min(1),
     name: z.string().min(1),
     defaultBranch: z.string().min(1),
-    localPath: z.string().min(1)
+    localPath: AbsoluteLocalPathSchema
   }),
   commands: RepoCommandSchema,
   context: z

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -58,8 +58,7 @@ function defaultArtifactId(): string {
 const ABSOLUTE_LOCAL_PATH_REGEX = /^(?:\/|[A-Za-z]:[\\/])/;
 const AbsoluteLocalPathSchema = z
   .string()
-  .min(1)
-  .refine((value) => ABSOLUTE_LOCAL_PATH_REGEX.test(value), {
+  .refine((value) => value.length > 0 && ABSOLUTE_LOCAL_PATH_REGEX.test(value), {
     message: "Local path must be an absolute path."
   });
 

--- a/tests/config-schema.test.ts
+++ b/tests/config-schema.test.ts
@@ -100,6 +100,14 @@ describe("target repo config schema", () => {
       ProjectConnectionInputSchema.parse({
         repoOwner: "acme",
         repoName: "app",
+        localPath: ""
+      })
+    ).toThrow(/absolute path/i);
+
+    expect(() =>
+      ProjectConnectionInputSchema.parse({
+        repoOwner: "acme",
+        repoName: "app",
         localPath: "repo/app"
       })
     ).toThrow(/absolute path/i);

--- a/tests/config-schema.test.ts
+++ b/tests/config-schema.test.ts
@@ -95,6 +95,52 @@ describe("target repo config schema", () => {
     expect(connection.localPath).toBe("C:/repo/app");
   });
 
+  it("requires absolute local paths for project connections", () => {
+    expect(() =>
+      ProjectConnectionInputSchema.parse({
+        repoOwner: "acme",
+        repoName: "app",
+        localPath: "repo/app"
+      })
+    ).toThrow(/absolute path/i);
+
+    expect(() =>
+      ProjectConnectionInputSchema.parse({
+        repoOwner: "acme",
+        repoName: "app",
+        localPath: "./repo/app"
+      })
+    ).toThrow(/absolute path/i);
+
+    expect(
+      ProjectConnectionInputSchema.parse({
+        repoOwner: "acme",
+        repoName: "app",
+        localPath: "/var/repo/app"
+      }).localPath
+    ).toBe("/var/repo/app");
+
+    expect(
+      ProjectConnectionInputSchema.parse({
+        repoOwner: "acme",
+        repoName: "app",
+        localPath: "C:\\repo\\app"
+      }).localPath
+    ).toBe("C:\\repo\\app");
+  });
+
+  it("requires absolute local paths in repo config", () => {
+    expect(() =>
+      TargetRepoConfigSchema.parse({
+        ...minimalConfig,
+        repo: {
+          ...minimalConfig.repo,
+          localPath: "repo/app"
+        }
+      })
+    ).toThrow(/absolute path/i);
+  });
+
   it("parses lazy MCP and capability activation rules", () => {
     const config = TargetRepoConfigSchema.parse({
       ...minimalConfig,


### PR DESCRIPTION
## Summary

Codex Cloud Backend/Core implemented queued issue #32 by enforcing absolute `localPath` values in project connection and target repo config schemas.

Closes #32

## Scope

[Codex Queue] Enforce absolute `localPath` for project connections

## Validation

- npm run check
- npm run logs:check
- docker compose config --no-interpolate --quiet

## Automation

- Stage: Backend/Core
- Run: https://github.com/onfire7777/five-agent-dev-team/actions/runs/25231108770
- Target: #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Validation for local path configuration now requires absolute paths and accepts both Unix (POSIX) and Windows drive-letter formats; relative or empty paths are rejected with clear "absolute path" error messaging.

* **Tests**
  * Added tests verifying schema rejects relative/empty local paths and accepts valid POSIX and Windows absolute paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->