### PR TITLE
Check Codex cloud PR publication permissions

### DIFF
--- a/.github/workflows/codex-cloud-meta-health.yml
+++ b/.github/workflows/codex-cloud-meta-health.yml
@@ -86,7 +86,7 @@ jobs:
                 owner,
                 repo,
                 path: ".github/workflows/codex-cloud-build-pipeline.yml",
-                ref: "main"
+                ref: mainSha
               });
               const workflowBody = Buffer.from(buildWorkflow.data.content, "base64").toString("utf8");
               buildWorkflowCanWritePullRequests = /^\s*pull-requests:\s*write\s*$/m.test(workflowBody);
@@ -99,11 +99,20 @@ jobs:
                 });
               }
             } catch (error) {
-              warnings.push({
-                class: "advisory",
-                title: "Codex Cloud Build Pipeline permission lookup unavailable",
-                detail: `Workflow file lookup failed: ${error.status || "unknown"}.`
-              });
+              if (error.status === 404) {
+                blockers.push({
+                  class: "globalStop",
+                  title: "Codex Cloud Build Pipeline workflow is missing",
+                  detail:
+                    "`.github/workflows/codex-cloud-build-pipeline.yml` was not found on the checked main revision, so PR publication cannot run."
+                });
+              } else {
+                warnings.push({
+                  class: "advisory",
+                  title: "Codex Cloud Build Pipeline permission lookup unavailable",
+                  detail: `Workflow file lookup failed: ${error.status || "unknown"}.`
+                });
+              }
             }
 
             const requiredContexts = [

--- a/.github/workflows/codex-cloud-meta-health.yml
+++ b/.github/workflows/codex-cloud-meta-health.yml
@@ -54,6 +54,58 @@ jobs:
               });
             }
 
+            let workflowPermissions = null;
+            try {
+              workflowPermissions = (
+                await github.request("GET /repos/{owner}/{repo}/actions/permissions/workflow", {
+                  owner,
+                  repo
+                })
+              ).data;
+              if (workflowPermissions.can_approve_pull_request_reviews !== true) {
+                blockers.push({
+                  class: "globalStop",
+                  title: "GitHub Actions PR publication policy is disabled",
+                  detail:
+                    "Codex Cloud Build Pipeline can generate and push branches, but PR publication can fail until repository Actions workflow permissions allow Actions-created or Actions-approved pull requests."
+                });
+              }
+            } catch (error) {
+              warnings.push({
+                class: "advisory",
+                title: "Actions workflow permission lookup unavailable",
+                detail: `Workflow permission lookup failed: ${
+                  error.status || "unknown"
+                }; admin-read token access may be required to verify PR publication capability.`
+              });
+            }
+
+            let buildWorkflowCanWritePullRequests = null;
+            try {
+              const buildWorkflow = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path: ".github/workflows/codex-cloud-build-pipeline.yml",
+                ref: "main"
+              });
+              const workflowBody = Buffer.from(buildWorkflow.data.content, "base64").toString("utf8");
+              buildWorkflowCanWritePullRequests = /^\s*pull-requests:\s*write\s*$/m.test(workflowBody);
+              if (!buildWorkflowCanWritePullRequests) {
+                blockers.push({
+                  class: "globalStop",
+                  title: "Codex Cloud Build Pipeline lacks pull-request write scope",
+                  detail:
+                    "Codex Cloud Build Pipeline must declare pull-requests: write so its GITHUB_TOKEN can publish implementation PRs."
+                });
+              }
+            } catch (error) {
+              warnings.push({
+                class: "advisory",
+                title: "Codex Cloud Build Pipeline permission lookup unavailable",
+                detail: `Workflow file lookup failed: ${error.status || "unknown"}.`
+              });
+            }
+
             const requiredContexts = [
               ...(protection?.required_status_checks?.contexts || []),
               ...(protection?.required_status_checks?.checks || []).map((check) => check.context)
@@ -178,6 +230,15 @@ jobs:
               `Repository: ${owner}/${repo}`,
               `main: ${mainSha}`,
               `Required checks: ${requiredLine}`,
+              `Actions default token permission: ${workflowPermissions?.default_workflow_permissions || "unavailable"}`,
+              `Actions PR policy enabled: ${
+                workflowPermissions?.can_approve_pull_request_reviews === undefined
+                  ? "unavailable"
+                  : String(workflowPermissions.can_approve_pull_request_reviews)
+              }`,
+              `Cloud build declares pull-requests write: ${
+                buildWorkflowCanWritePullRequests === null ? "unavailable" : String(buildWorkflowCanWritePullRequests)
+              }`,
               `Open PRs: ${openPrs.length}`,
               `Open queued/running agent issues: ${queueIssues.length}`,
               `Open Dependabot alerts: ${dependabotOpen === null ? "unavailable" : dependabotOpen}`,


### PR DESCRIPTION
## Summary

Adds Meta Health coverage for the PR-publication permissions that the Codex Cloud Build Pipeline needs for continuous scheduled operation.

## Scope

- Checks the repository Actions workflow policy used for Actions-created or Actions-approved pull requests.
- Checks that the Codex Cloud Build Pipeline declares `pull-requests: write`.
- Reports both values in the Meta Health summary and opens a global stop if the build workflow cannot publish PRs.

## Validation

- npx prettier --check .github/workflows/codex-cloud-meta-health.yml
- node YAML parse
- git diff --check
- npm run logs:check
- coderabbit review --agent -t uncommitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Repository health checks now validate PR approval permissions and workflow permission policy.
  * Added validation for build pipeline PR write permission presence and explicit declaration.
  * Health check reports include permission findings with clear fallback wording ("unavailable") when values can't be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->