### PR TITLE
Harden Codex cloud PR publication

### DIFF
--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -220,6 +220,8 @@ jobs:
                 .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
               for (const pr of sortedPrs) {
                 const labelNames = pr.labels.map((label) => label.name);
+                const isCodexCloudPr =
+                  labelNames.includes("agent:ready-for-review") && pr.head.ref.startsWith("codex/cloud-");
                 const hasBlockingLabel = labelNames.some((label) =>
                   [
                     "codex-status:blocked",
@@ -229,7 +231,7 @@ jobs:
                     "codex-blocker:scope"
                   ].includes(label)
                 );
-                if (!labelNames.includes("codex-status:ready-to-merge") || hasBlockingLabel) {
+                if (!isCodexCloudPr || !labelNames.includes("codex-status:ready-to-merge") || hasBlockingLabel) {
                   continue;
                 }
                 const review = await github.graphql(
@@ -429,7 +431,8 @@ jobs:
             npm run test:e2e
           fi
 
-      - name: Create implementation PR
+      - name: Create or reuse implementation PR
+        id: publish_pr
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -446,7 +449,7 @@ jobs:
           git switch -c "$branch"
           git add -A
           git commit -m "Codex Cloud ${STAGE_DISPLAY}: issue #${TARGET_NUMBER}"
-          git push origin "$branch"
+          git push --force-with-lease origin "$branch"
 
           {
             echo "## Summary"
@@ -478,16 +481,36 @@ jobs:
             echo "- Target: #${TARGET_NUMBER}"
           } > pr-body.md
 
-          gh pr create \
-            --base main \
-            --head "$branch" \
-            --title "Codex Cloud ${STAGE_DISPLAY}: ${TARGET_TITLE}" \
-            --body-file pr-body.md \
-            --label "$STAGE_LABEL" \
-            --label agent:ready-for-review \
-            --label codex-status:needs-review
+          pr_number="$(gh pr list --head "$branch" --base main --state open --json number --jq '.[0].number // ""')"
+          if [ -z "$pr_number" ]; then
+            gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "Codex Cloud ${STAGE_DISPLAY}: ${TARGET_TITLE}" \
+              --body-file pr-body.md \
+              --label "$STAGE_LABEL" \
+              --label agent:ready-for-review \
+              --label codex-status:needs-review
+            pr_number="$(gh pr list --head "$branch" --base main --state open --json number --jq '.[0].number // ""')"
+          fi
 
+          if [ -z "$pr_number" ]; then
+            echo "Unable to determine implementation PR number for $branch" >&2
+            exit 1
+          fi
+
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Update target issue state
+        if: steps.publish_pr.outputs.pr_number != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_NUMBER: ${{ steps.gate.outputs.target_number }}
+        shell: bash
+        run: |
           gh issue edit "$TARGET_NUMBER" --add-label agent:ready-for-review
+
           gh issue edit "$TARGET_NUMBER" --remove-label agent:running --remove-label agent:claimed || true
 
       - name: Captain merge gate

--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -509,8 +509,7 @@ jobs:
           TARGET_NUMBER: ${{ steps.gate.outputs.target_number }}
         shell: bash
         run: |
-          gh issue edit "$TARGET_NUMBER" --add-label agent:ready-for-review
-
+          gh issue edit "$TARGET_NUMBER" --add-label agent:ready-for-review || true
           gh issue edit "$TARGET_NUMBER" --remove-label agent:running --remove-label agent:claimed || true
 
       - name: Captain merge gate


### PR DESCRIPTION
## Summary

Hardens Codex Cloud Build Pipeline PR publication and Captain auto-merge selection.

## Scope

- Captain now only considers PRs that look like cloud-created implementation PRs: `agent:ready-for-review` plus `codex/cloud-*` branch names.
- Implementation PR publication now uses an idempotent create-or-reuse path.
- Issue label updates are split into a separate tolerant step so a label-edit hiccup does not mark a successfully published PR as blocked.

## Validation

- npx prettier --check .github/workflows/codex-cloud-build-pipeline.yml
- node YAML parse
- git diff --check
- npm run logs:check
- coderabbit review --agent -t uncommitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened CI/CD PR selection to only consider properly labeled and specifically named cloud-related branches, reducing false candidates.
  * Improved PR publication to detect and reuse existing implementation pull requests, preventing duplicate PRs and recording the published PR reference.
  * Updated workflow to conditionally adjust issue labels after PR publication for clearer and more accurate status tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->