### PR TITLE
Use Gitleaks binary for secret scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,21 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc
+      - name: Install Gitleaks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: v8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          archive="gitleaks_${GITLEAKS_VERSION#v}_linux_x64.tar.gz"
+          gh release download "$GITLEAKS_VERSION" \
+            --repo gitleaks/gitleaks \
+            --pattern "$archive"
+          echo "$GITLEAKS_SHA256  $archive" | sha256sum --check -
+          tar -xzf "$archive" gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+      - name: Run Gitleaks
+        run: gitleaks detect --source . --redact --verbose
 
   compose-config:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- replace the deprecated Node-based Gitleaks action wrapper with a pinned Gitleaks CLI binary install
- verify the release archive against the upstream checksum file before installing
- keep secret scanning in its own least-privilege job

## Validation
- npx prettier --check .github/workflows/ci.yml
- node YAML parse for .github/workflows/ci.yml
- git diff --check
- coderabbit review --agent -t uncommitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI secret-scanning workflow to install and verify a specific gitleaks release and run repository scans directly for more reliable and validated security checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->