### PR TITLE
Harden Codex cloud lane routing

### DIFF
--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -94,6 +94,71 @@ jobs:
               state: "open",
               per_page: 100
             });
+            const laneOrder = ["backend", "frontend", "quality", "security", "docs"];
+            const issueField = (issue, name) =>
+              (issue.body || "").match(new RegExp(`^${name}:\\s*(.+)$`, "im"))?.[1]?.toLowerCase() || "";
+            const inferIssueLane = (issue) => {
+              const labeledLane = issue.labels
+                .map((label) => label.name)
+                .find((label) => label.startsWith("lane:"))
+                ?.slice("lane:".length);
+              const expectedFiles = issueField(issue, "Expected files");
+              const problem = issueField(issue, "Problem");
+              const title = (issue.title || "").toLowerCase();
+              const basis = `${title}\n${problem}\n${expectedFiles}`;
+              if (
+                expectedFiles.includes(".github/") ||
+                expectedFiles.includes("dockerfile") ||
+                expectedFiles.includes("docker-compose") ||
+                expectedFiles.includes("package.json") ||
+                expectedFiles.includes("package-lock.json") ||
+                expectedFiles.includes("release/") ||
+                /\b(ci|workflow|github actions|gitleaks|secret scan|docker|compose|audit|permission|auth|release)\b/.test(basis)
+              ) {
+                return "security";
+              }
+              if (
+                expectedFiles.includes("apps/controller/") ||
+                expectedFiles.includes("apps/worker/") ||
+                expectedFiles.includes("packages/shared/") ||
+                expectedFiles.includes("packages/github/")
+              ) {
+                return "backend";
+              }
+              if (expectedFiles.includes("apps/dashboard/")) return "frontend";
+              if (
+                expectedFiles.includes("tests/") ||
+                expectedFiles.includes("playwright.config") ||
+                /\b(test|playwright|e2e|acceptance evidence|reproduction)\b/.test(basis)
+              ) {
+                return "quality";
+              }
+              if (
+                expectedFiles.includes("readme.md") ||
+                expectedFiles.includes("docs/") ||
+                expectedFiles.includes("release notes") ||
+                /\b(docs|documentation|runbook|release notes)\b/.test(basis)
+              ) {
+                return "docs";
+              }
+              return laneOrder.includes(labeledLane) ? labeledLane : "";
+            };
+            const syncLaneLabels = async (issue, lane) => {
+              const labelNames = issue.labels.map((label) => label.name);
+              const currentLane = labelNames.find((label) => label.startsWith("lane:"));
+              if (currentLane === `lane:${lane}`) return;
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issue.number,
+                labels: [`lane:${lane}`]
+              });
+              for (const label of labelNames.filter((name) => name.startsWith("lane:") && name !== `lane:${lane}`)) {
+                try {
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: issue.number, name: label });
+                } catch {}
+              }
+            };
 
             if (autoFromResearch) {
               if (context.payload.workflow_run.conclusion !== "success") {
@@ -104,16 +169,11 @@ jobs:
                 return;
               }
 
-              const laneOrder = ["backend", "frontend", "quality", "security", "docs"];
               const queuedTargets = openIssues
                 .filter((issue) => issue.labels.some((label) => label.name === "agent:queued"))
                 .filter((issue) => issue.labels.some((label) => label.name === "execution:codex-cloud"))
                 .map((issue) => {
-                  const laneLabel = issue.labels
-                    .map((label) => label.name)
-                    .find((label) => label.startsWith("lane:"));
-                  const lane = laneLabel?.slice("lane:".length);
-                  return { issue, lane };
+                  return { issue, lane: inferIssueLane(issue) };
                 })
                 .filter((item) => laneOrder.includes(item.lane))
                 .sort((a, b) => {
@@ -131,6 +191,7 @@ jobs:
               }
 
               stage = queuedTargets[0].lane;
+              await syncLaneLabels(queuedTargets[0].issue, stage);
             } else if (autoFromCi) {
               if (context.payload.workflow_run.conclusion !== "success") {
                 core.setOutput("stage", "captain");
@@ -226,7 +287,7 @@ jobs:
               }
               const target = openIssues
                 .filter((issue) => issue.labels.some((label) => label.name === "agent:queued"))
-                .filter((issue) => issue.labels.some((label) => label.name === `lane:${stageInfo.lane}`))
+                .filter((issue) => inferIssueLane(issue) === stageInfo.lane)
                 .filter((issue) => issue.labels.some((label) => label.name === "execution:codex-cloud"))
                 .sort((a, b) => new Date(a.created_at) - new Date(b.created_at))[0];
               if (!target) {
@@ -250,6 +311,7 @@ jobs:
                 );
                 return;
               }
+              await syncLaneLabels(target, stageInfo.lane);
               await github.rest.issues.addLabels({
                 owner,
                 repo,

--- a/.github/workflows/codex-cloud-research.yml
+++ b/.github/workflows/codex-cloud-research.yml
@@ -124,6 +124,13 @@ jobs:
             Do not edit files, propose dependencies, merge, push, or mark acceptance complete.
             Only propose work that maps to the implementation spec and real product behavior, and can run in codex-cloud, codex-action, or agentic-workflow.
             When no PR or active queue issue exists, prefer producing the next bounded implementation slice from docs/implementation-spec.md.
+            Choose the lane from the expected file ownership, not from the broad topic:
+            - backend: apps/controller/**, apps/worker/**, packages/shared/**, packages/github/**, backend/schema/store/controller tests.
+            - frontend: apps/dashboard/** and dashboard e2e coverage.
+            - quality: tests/**, Playwright config, test utilities, reproductions, and acceptance evidence only.
+            - security: .github/**, CI workflows, Dockerfile, docker-compose.yml, .env.example, package*.json, audit/security/check scripts, release/**, auth/security/permission work.
+            - docs: README.md, docs/**, release notes, runbooks, and acceptance docs.
+            If Expected files include .github/** or CI workflow changes, Lane assignment must be security.
             If no non-overlapping product-spec-backed work scores at least 22/30, output exactly:
             QUEUE_ITEM_READY: no
 


### PR DESCRIPTION
## Summary
- add explicit Stage 0 lane ownership rules so CI/workflow work routes to Security/DevOps
- infer queued issue lane from expected files in the cloud build gate
- synchronize stale lane labels before claiming queued cloud work

## Validation
- npm run check

## Context
Issue #40 was generated as a CI workflow task but assigned to the quality lane, causing a no-op lane-stop. This prevents the same class of residue from blocking future cloud handoffs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated issue routing and lane assignment logic in CI/CD workflows for more reliable classification.
  * Enhanced lane label consistency and management to ensure proper issue organization and processing.
  * Updated workflow instructions for clearer lane-based issue categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->