### PR TITLE
Enable cloud workflow publishing and Node 24 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,19 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  static-check:
+  static-check-node:
+    name: static-check (${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
@@ -35,30 +40,56 @@ jobs:
       - run: npm run format:check
       - run: git diff --check
 
-  unit-integration:
+  static-check:
+    name: static-check
+    runs-on: ubuntu-latest
+    needs: static-check-node
+    timeout-minutes: 5
+    steps:
+      - run: echo "Node 22 and 24 static checks passed."
+
+  unit-integration-node:
+    name: unit-integration (${{ matrix.node-version }})
     runs-on: ubuntu-latest
     needs: static-check
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
       - run: npm test
       - run: npm run build
 
-  e2e:
+  unit-integration:
+    name: unit-integration
+    runs-on: ubuntu-latest
+    needs: unit-integration-node
+    timeout-minutes: 5
+    steps:
+      - run: echo "Node 22 and 24 unit/integration checks passed."
+
+  e2e-node:
+    name: e2e (${{ matrix.node-version }})
     runs-on: ubuntu-latest
     needs: unit-integration
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
@@ -74,19 +105,40 @@ jobs:
             test-results/
           if-no-files-found: ignore
 
-  security-audit:
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    needs: e2e-node
+    timeout-minutes: 5
+    steps:
+      - run: echo "Node 22 and 24 e2e checks passed."
+
+  security-audit-node:
+    name: security-audit (${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
       - run: npm audit --audit-level=high
       - run: npm run audit:security
+
+  security-audit:
+    name: security-audit
+    runs-on: ubuntu-latest
+    needs: security-audit-node
+    timeout-minutes: 5
+    steps:
+      - run: echo "Node 22 and 24 security audits passed."
 
   secret-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -491,6 +491,7 @@ jobs:
             - Do not invent unqueued feature scope.
             - Add or update tests when behavior changes.
             - Leave a concise summary in codex-output.md.
+            - Do not ask follow-up questions. Either make the bounded change, or write a precise BLOCKED reason in codex-output.md.
 
             Expected verification before PR publication:
             ${{ steps.gate.outputs.verify_hint }}
@@ -556,7 +557,8 @@ jobs:
         id: publish_pr
         if: steps.changes.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          CODEX_PUSH_TOKEN: ${{ secrets.CODEX_WORKFLOW_PUSH_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.CODEX_WORKFLOW_PUSH_TOKEN || github.token }}
           STAGE: ${{ steps.gate.outputs.stage }}
           STAGE_DISPLAY: ${{ steps.gate.outputs.stage_display }}
           STAGE_LABEL: ${{ steps.gate.outputs.stage_label }}
@@ -570,6 +572,7 @@ jobs:
           git switch -c "$branch"
           git add -A
           git commit -m "Codex Cloud ${STAGE_DISPLAY}: issue #${TARGET_NUMBER}"
+          git remote set-url origin "https://x-access-token:${CODEX_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push --force-with-lease origin "$branch"
 
           {


### PR DESCRIPTION
## Summary
- add Node 22/24 matrices to Node-based CI jobs
- add CODEX_WORKFLOW_PUSH_TOKEN support for Codex cloud PR branch publishing
- prevent Codex cloud build prompts from ending with follow-up questions instead of a clear change or blocker

Closes #40

## Validation
- npm run check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- npm run audit:security
- git diff --check

## Operational note
The repo now has an encrypted Actions secret named CODEX_WORKFLOW_PUSH_TOKEN so cloud runs can publish workflow-file changes that the default GITHUB_TOKEN cannot push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline expanded to run verification across Node.js 22 and 24 with per-version job runs and aggregated reporting, and adjusted job timeouts for more reliable multi-version testing.
  * Build automation hardened: automated branch publishing now uses improved token-based publishing and the generation stage enforces clearer, non-interactive instructions for produced changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->