### PR TITLE
Add GitHub CLI and MCP helpers

### DIFF
--- a/apps/worker/src/activities.ts
+++ b/apps/worker/src/activities.ts
@@ -31,6 +31,7 @@ import {
   runRoleAgent,
   type TeamBusMessage
 } from "../../../packages/agents/src";
+import { listWorkflowRuns } from "../../../packages/github/src";
 import { createStore, type ControllerStore, type StrictProjectScope } from "../../controller/src/store";
 
 const exec = util.promisify(childProcess.exec);
@@ -904,16 +905,16 @@ async function readGitHubActionsEvidence(config: TargetRepoConfig): Promise<Evid
   }
 
   try {
-    const result = await exec(
-      `gh run list --repo ${repo} --branch ${branch} --limit 1 --json status,conclusion,url,workflowName,headSha`,
-      {
+    const runs = await listWorkflowRuns({
+      repo,
+      branch,
+      limit: 1,
+      options: {
         cwd: repoPath,
-        env: githubAuthEnv(),
         timeout: 30_000,
         maxBuffer: 1024 * 1024
       }
-    );
-    const runs = JSON.parse(result.stdout || "[]") as Array<Record<string, unknown>>;
+    });
     const latest = runs[0];
     if (!latest) {
       const summary = `No GitHub Actions runs were found for ${repo}@${branch}.`;

--- a/packages/github/src/gh.ts
+++ b/packages/github/src/gh.ts
@@ -1,0 +1,204 @@
+import childProcess from "node:child_process";
+import util from "node:util";
+import { githubAuthEnv } from "../../shared/src";
+
+const execFile = util.promisify(childProcess.execFile);
+
+export interface GhExecOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeout?: number;
+  maxBuffer?: number;
+}
+
+export interface GhExecResult {
+  stdout: string;
+  stderr: string;
+}
+
+export type GhExec = (args: readonly string[], options: GhExecOptions) => Promise<GhExecResult>;
+
+export interface GhCommandOptions extends GhExecOptions {
+  exec?: GhExec;
+}
+
+export interface GhWorkflowRun {
+  status: string;
+  conclusion: string;
+  url: string;
+  workflowName: string;
+  headSha: string;
+}
+
+export interface GhPullRequest {
+  number: number;
+  title: string;
+  state: string;
+  isDraft: boolean;
+  mergeStateStatus: string;
+  reviewDecision: string;
+  headRefName: string;
+  headRefOid: string;
+  url: string;
+}
+
+export interface GhRelease {
+  tagName: string;
+  name: string;
+  isDraft: boolean;
+  isPrerelease: boolean;
+  url: string;
+  targetCommitish: string;
+  publishedAt: string;
+}
+
+export async function listWorkflowRuns(input: {
+  repo: string;
+  branch?: string;
+  limit?: number;
+  options?: GhCommandOptions;
+}): Promise<GhWorkflowRun[]> {
+  const args = [
+    "run",
+    "list",
+    "--repo",
+    input.repo,
+    ...(input.branch ? ["--branch", input.branch] : []),
+    "--limit",
+    String(input.limit ?? 1),
+    "--json",
+    "status,conclusion,url,workflowName,headSha"
+  ];
+  const runs = await runGhJson<unknown>(args, input.options, "gh run list");
+  if (!Array.isArray(runs)) {
+    throw new Error("gh run list returned JSON that is not an array.");
+  }
+  return runs.map((run) => {
+    const value = objectRecord(run, "gh run list item");
+    return {
+      status: stringField(value, "status", "unknown"),
+      conclusion: stringField(value, "conclusion", "unknown"),
+      url: stringField(value, "url", ""),
+      workflowName: stringField(value, "workflowName", ""),
+      headSha: stringField(value, "headSha", "")
+    };
+  });
+}
+
+export async function viewPullRequest(input: {
+  repo: string;
+  pullNumber: number;
+  options?: GhCommandOptions;
+}): Promise<GhPullRequest> {
+  const pull = objectRecord(
+    await runGhJson<unknown>(
+      [
+        "pr",
+        "view",
+        String(input.pullNumber),
+        "--repo",
+        input.repo,
+        "--json",
+        "number,title,state,isDraft,mergeStateStatus,reviewDecision,headRefName,headRefOid,url"
+      ],
+      input.options,
+      "gh pr view"
+    ),
+    "gh pr view"
+  );
+  return {
+    number: numberField(pull, "number"),
+    title: stringField(pull, "title", ""),
+    state: stringField(pull, "state", ""),
+    isDraft: booleanField(pull, "isDraft"),
+    mergeStateStatus: stringField(pull, "mergeStateStatus", ""),
+    reviewDecision: stringField(pull, "reviewDecision", ""),
+    headRefName: stringField(pull, "headRefName", ""),
+    headRefOid: stringField(pull, "headRefOid", ""),
+    url: stringField(pull, "url", "")
+  };
+}
+
+export async function viewRelease(input: {
+  repo: string;
+  tag: string;
+  options?: GhCommandOptions;
+}): Promise<GhRelease> {
+  const release = objectRecord(
+    await runGhJson<unknown>(
+      [
+        "release",
+        "view",
+        input.tag,
+        "--repo",
+        input.repo,
+        "--json",
+        "tagName,name,isDraft,isPrerelease,url,targetCommitish,publishedAt"
+      ],
+      input.options,
+      "gh release view"
+    ),
+    "gh release view"
+  );
+  return {
+    tagName: stringField(release, "tagName", ""),
+    name: stringField(release, "name", ""),
+    isDraft: booleanField(release, "isDraft"),
+    isPrerelease: booleanField(release, "isPrerelease"),
+    url: stringField(release, "url", ""),
+    targetCommitish: stringField(release, "targetCommitish", ""),
+    publishedAt: stringField(release, "publishedAt", "")
+  };
+}
+
+async function runGhJson<T>(args: readonly string[], options: GhCommandOptions | undefined, label: string): Promise<T> {
+  const result = await runGh(args, options);
+  const stdout = result.stdout.trim() || "null";
+  try {
+    return JSON.parse(stdout) as T;
+  } catch (error) {
+    throw new Error(`${label} returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function runGh(args: readonly string[], options: GhCommandOptions = {}): Promise<GhExecResult> {
+  const runner = options.exec ?? defaultGhExec;
+  return runner(args, {
+    cwd: options.cwd,
+    env: githubAuthEnv(options.env),
+    timeout: options.timeout ?? 30_000,
+    maxBuffer: options.maxBuffer ?? 1024 * 1024
+  });
+}
+
+async function defaultGhExec(args: readonly string[], options: GhExecOptions): Promise<GhExecResult> {
+  const result = await execFile("gh", [...args], {
+    cwd: options.cwd,
+    env: options.env,
+    timeout: options.timeout,
+    maxBuffer: options.maxBuffer
+  });
+  return { stdout: result.stdout, stderr: result.stderr };
+}
+
+function objectRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} returned JSON that is not an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function stringField(value: Record<string, unknown>, key: string, fallback: string): string {
+  const field = value[key];
+  return typeof field === "string" ? field : fallback;
+}
+
+function numberField(value: Record<string, unknown>, key: string): number {
+  const field = value[key];
+  if (typeof field !== "number") throw new Error(`Expected numeric ${key} in gh JSON output.`);
+  return field;
+}
+
+function booleanField(value: Record<string, unknown>, key: string): boolean {
+  return value[key] === true;
+}

--- a/packages/github/src/gh.ts
+++ b/packages/github/src/gh.ts
@@ -200,5 +200,7 @@ function numberField(value: Record<string, unknown>, key: string): number {
 }
 
 function booleanField(value: Record<string, unknown>, key: string): boolean {
-  return value[key] === true;
+  const field = value[key];
+  if (typeof field !== "boolean") throw new Error(`Expected boolean ${key} in gh JSON output.`);
+  return field;
 }

--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -1,1 +1,3 @@
 export * from "./client";
+export * from "./gh";
+export * from "./mcp";

--- a/packages/github/src/mcp.ts
+++ b/packages/github/src/mcp.ts
@@ -1,0 +1,31 @@
+export interface GitHubMcpStdioConfig {
+  name: string;
+  category: "github";
+  transport: "stdio";
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+export interface GitHubMcpConfigInput {
+  name?: string;
+  command?: string;
+  readOnly?: boolean;
+  tokenEnv?: string;
+  extraArgs?: string[];
+}
+
+export function buildGitHubMcpStdioConfig(input: GitHubMcpConfigInput = {}): GitHubMcpStdioConfig {
+  const tokenEnv = input.tokenEnv || "GITHUB_PERSONAL_ACCESS_TOKEN";
+  return {
+    name: input.name || "github-mcp",
+    category: "github",
+    transport: "stdio",
+    command: input.command || "github-mcp-server",
+    args: ["stdio", ...(input.readOnly === false ? [] : ["--read-only"]), ...(input.extraArgs || [])],
+    env: {
+      GITHUB_PERSONAL_ACCESS_TOKEN: `\${${tokenEnv}}`,
+      GITHUB_TOKEN: `\${${tokenEnv}}`
+    }
+  };
+}

--- a/tests/github-cli.test.ts
+++ b/tests/github-cli.test.ts
@@ -121,6 +121,27 @@ describe("GitHub CLI helpers", () => {
       /gh run list returned invalid JSON/
     );
   });
+
+  it("fails fast when boolean gh fields drift from the expected schema", async () => {
+    const exec: GhExec = async () => ({
+      stdout: JSON.stringify({
+        number: 7,
+        title: "Ready",
+        state: "OPEN",
+        isDraft: "false",
+        mergeStateStatus: "CLEAN",
+        reviewDecision: "APPROVED",
+        headRefName: "codex/test",
+        headRefOid: "def456",
+        url: "https://github.com/owner/repo/pull/7"
+      }),
+      stderr: ""
+    });
+
+    await expect(viewPullRequest({ repo: "owner/repo", pullNumber: 7, options: { exec } })).rejects.toThrow(
+      /Expected boolean isDraft/
+    );
+  });
 });
 
 describe("GitHub MCP config", () => {

--- a/tests/github-cli.test.ts
+++ b/tests/github-cli.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildGitHubMcpStdioConfig,
+  listWorkflowRuns,
+  viewPullRequest,
+  viewRelease,
+  type GhExec,
+  type GhExecOptions
+} from "../packages/github/src";
+
+const originalGithubToken = process.env.GITHUB_TOKEN;
+
+afterEach(() => {
+  if (originalGithubToken === undefined) {
+    delete process.env.GITHUB_TOKEN;
+  } else {
+    process.env.GITHUB_TOKEN = originalGithubToken;
+  }
+});
+
+describe("GitHub CLI helpers", () => {
+  it("lists workflow runs with typed parsing and GitHub auth environment", async () => {
+    process.env.GITHUB_TOKEN = "test-token";
+    const calls: Array<{ args: readonly string[]; options: GhExecOptions }> = [];
+    const exec: GhExec = async (args, options) => {
+      calls.push({ args: [...args], options });
+      return {
+        stdout: JSON.stringify([
+          {
+            status: "completed",
+            conclusion: "success",
+            url: "https://github.com/owner/repo/actions/runs/1",
+            workflowName: "CI",
+            headSha: "abc123"
+          }
+        ]),
+        stderr: ""
+      };
+    };
+
+    const runs = await listWorkflowRuns({
+      repo: "owner/repo",
+      branch: "main",
+      limit: 1,
+      options: { cwd: "C:\\repo", exec }
+    });
+
+    expect(runs).toEqual([
+      {
+        status: "completed",
+        conclusion: "success",
+        url: "https://github.com/owner/repo/actions/runs/1",
+        workflowName: "CI",
+        headSha: "abc123"
+      }
+    ]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual([
+      "run",
+      "list",
+      "--repo",
+      "owner/repo",
+      "--branch",
+      "main",
+      "--limit",
+      "1",
+      "--json",
+      "status,conclusion,url,workflowName,headSha"
+    ]);
+    expect(calls[0].options.cwd).toBe("C:\\repo");
+    expect(calls[0].options.env?.GITHUB_TOKEN).toBe("test-token");
+  });
+
+  it("views pull request and release metadata with typed fields", async () => {
+    const exec: GhExec = async (args) => {
+      if (args[0] === "pr") {
+        return {
+          stdout: JSON.stringify({
+            number: 7,
+            title: "Ready",
+            state: "OPEN",
+            isDraft: false,
+            mergeStateStatus: "CLEAN",
+            reviewDecision: "APPROVED",
+            headRefName: "codex/test",
+            headRefOid: "def456",
+            url: "https://github.com/owner/repo/pull/7"
+          }),
+          stderr: ""
+        };
+      }
+      return {
+        stdout: JSON.stringify({
+          tagName: "v1.0.0",
+          name: "v1.0.0",
+          isDraft: false,
+          isPrerelease: false,
+          url: "https://github.com/owner/repo/releases/tag/v1.0.0",
+          targetCommitish: "main",
+          publishedAt: "2026-05-02T00:00:00Z"
+        }),
+        stderr: ""
+      };
+    };
+
+    await expect(viewPullRequest({ repo: "owner/repo", pullNumber: 7, options: { exec } })).resolves.toMatchObject({
+      number: 7,
+      mergeStateStatus: "CLEAN",
+      reviewDecision: "APPROVED"
+    });
+    await expect(viewRelease({ repo: "owner/repo", tag: "v1.0.0", options: { exec } })).resolves.toMatchObject({
+      tagName: "v1.0.0",
+      targetCommitish: "main"
+    });
+  });
+
+  it("reports invalid JSON from gh output with command context", async () => {
+    const exec: GhExec = async () => ({ stdout: "{not-json", stderr: "" });
+
+    await expect(listWorkflowRuns({ repo: "owner/repo", options: { exec } })).rejects.toThrow(
+      /gh run list returned invalid JSON/
+    );
+  });
+});
+
+describe("GitHub MCP config", () => {
+  it("builds read-only and write-capable stdio configs with env placeholders", () => {
+    expect(buildGitHubMcpStdioConfig()).toMatchObject({
+      name: "github-mcp",
+      category: "github",
+      transport: "stdio",
+      command: "github-mcp-server",
+      args: ["stdio", "--read-only"],
+      env: {
+        GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PERSONAL_ACCESS_TOKEN}",
+        GITHUB_TOKEN: "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    });
+
+    expect(
+      buildGitHubMcpStdioConfig({ readOnly: false, tokenEnv: "GITHUB_TOKEN", extraArgs: ["--toolsets", "repos"] })
+    ).toMatchObject({
+      args: ["stdio", "--toolsets", "repos"],
+      env: {
+        GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_TOKEN}",
+        GITHUB_TOKEN: "${GITHUB_TOKEN}"
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds typed GitHub CLI helpers for workflow runs, PR metadata, and release metadata.
- Adds GitHub MCP stdio config construction with read-only default and write-capable override.
- Reuses the workflow-run helper in the worker GitHub Actions evidence path.

## Validation
- npm test -- tests/github-cli.test.ts tests/release-activities.test.ts
- npm run check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- npm run audit:security
- git diff --check
- coderabbit review --plain --type uncommitted --base main --no-color

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub CLI integration with typed helpers for workflow runs, pull requests, and releases.
  * Added a builder for GitHub MCP stdio configuration with sensible defaults and token wiring.

* **Refactor**
  * Activity logic now uses the shared GitHub CLI helpers instead of invoking shell commands directly.

* **Tests**
  * Added comprehensive tests covering CLI parsing, error handling, and MCP config behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->