### PR TITLE
Harden cloud automation recovery and event backfill

### DIFF
--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -98,6 +98,8 @@ jobs:
             const issueField = (issue, name) =>
               (issue.body || "").match(new RegExp(`^${name}:\\s*(.+)$`, "im"))?.[1]?.toLowerCase() || "";
             const inferIssueLane = (issue) => {
+              const explicitLane = issueField(issue, "Lane assignment");
+              if (laneOrder.includes(explicitLane)) return explicitLane;
               const labeledLane = issue.labels
                 .map((label) => label.name)
                 .find((label) => label.startsWith("lane:"))
@@ -112,8 +114,7 @@ jobs:
                 expectedFiles.includes("docker-compose") ||
                 expectedFiles.includes("package.json") ||
                 expectedFiles.includes("package-lock.json") ||
-                expectedFiles.includes("release/") ||
-                /\b(ci|workflow|github actions|gitleaks|secret scan|docker|compose|audit|permission|auth|release)\b/.test(basis)
+                expectedFiles.includes("release/")
               ) {
                 return "security";
               }
@@ -140,6 +141,9 @@ jobs:
                 /\b(docs|documentation|runbook|release notes)\b/.test(basis)
               ) {
                 return "docs";
+              }
+              if (/\b(ci|github actions|gitleaks|secret scan|docker|compose|audit|permission)\b/.test(basis)) {
+                return "security";
               }
               return laneOrder.includes(labeledLane) ? labeledLane : "";
             };
@@ -458,6 +462,10 @@ jobs:
           echo "OPENAI_API_KEY is required for Codex Cloud Build Pipeline." >&2
           exit 1
 
+      - name: Install Playwright system dependencies
+        if: steps.gate.outputs.should_run == 'true' && steps.gate.outputs.target_kind == 'issue' && env.OPENAI_API_KEY != '' && (steps.gate.outputs.stage == 'frontend' || steps.gate.outputs.stage == 'quality')
+        run: npx playwright install --with-deps chromium
+
       - name: Run Codex cloud build stage
         id: run_codex
         if: steps.gate.outputs.should_run == 'true' && steps.gate.outputs.target_kind == 'issue' && env.OPENAI_API_KEY != ''
@@ -486,6 +494,8 @@ jobs:
             Rules:
             - Implement only the queued issue scope.
             - Stay inside owned files: ${{ steps.gate.outputs.owned_files }}.
+            - This GitHub Actions run already claimed the issue with GitHub labels. Do not require local Windows state files under C:\Users\burni\.codex, and do not block only because those local control files are absent in the cloud runner.
+            - Treat the checked-out GitHub Actions workspace as the authoritative branch context. Do not run git fetch if the cloud checkout refuses writes to .git/FETCH_HEAD.
             - Keep the diff bounded and avoid unrelated cleanup.
             - Do not print secrets, weaken security gates, change branch protection, or push main.
             - Do not invent unqueued feature scope.
@@ -519,8 +529,15 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
+            const fs = require("fs");
+            const path = require("path");
             const issue_number = Number("${{ steps.gate.outputs.target_number }}");
             const { owner, repo } = context.repo;
+            const outputPath = path.join(process.env.RUNNER_TEMP, "codex-cloud-artifacts", "codex-output.md");
+            const output = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, "utf8").trim() : "";
+            const outputBlock = output
+              ? `\n\nCodex output:\n\n\`\`\`text\n${output.slice(0, 2500)}\n\`\`\``
+              : "";
             await github.rest.issues.addLabels({
               owner,
               repo,
@@ -536,7 +553,7 @@ jobs:
               owner,
               repo,
               issue_number,
-              body: `Codex Cloud ${{ steps.gate.outputs.stage_display }} ran but produced no file changes. The issue is blocked for lane triage.\n\nRun: ${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${context.runId}`
+              body: `Codex Cloud ${{ steps.gate.outputs.stage_display }} ran but produced no file changes. The issue is blocked for lane triage.\n\nRun: ${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${context.runId}${outputBlock}`
             });
 
       - name: Format generated changes
@@ -557,14 +574,12 @@ jobs:
           docker compose config --no-interpolate --quiet
           git diff --check
           if [ "${{ steps.gate.outputs.stage }}" = "frontend" ]; then
-            npx playwright install --with-deps chromium
             npm run test:e2e -- tests/e2e/dashboard-smoke.spec.ts
           fi
           if [ "${{ steps.gate.outputs.stage }}" = "security" ]; then
             npm run audit:security
           fi
           if [ "${{ steps.gate.outputs.stage }}" = "quality" ]; then
-            npx playwright install --with-deps chromium
             npm run test:e2e
           fi
 
@@ -711,8 +726,15 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
+            const fs = require("fs");
+            const path = require("path");
             const issue_number = Number("${{ steps.gate.outputs.target_number }}");
             const { owner, repo } = context.repo;
+            const outputPath = path.join(process.env.RUNNER_TEMP, "codex-cloud-artifacts", "codex-output.md");
+            const output = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, "utf8").trim() : "";
+            const outputBlock = output
+              ? `\n\nCodex output:\n\n\`\`\`text\n${output.slice(0, 2500)}\n\`\`\``
+              : "";
             await github.rest.issues.addLabels({
               owner,
               repo,
@@ -728,7 +750,7 @@ jobs:
               owner,
               repo,
               issue_number,
-              body: `Codex Cloud ${{ steps.gate.outputs.stage_display }} failed verification or PR publication and routed this item as blocked.\n\nRun: ${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${context.runId}`
+              body: `Codex Cloud ${{ steps.gate.outputs.stage_display }} failed verification or PR publication and routed this item as blocked.\n\nRun: ${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${context.runId}${outputBlock}`
             });
 
       - name: Upload Codex build output

--- a/.github/workflows/codex-cloud-meta-health.yml
+++ b/.github/workflows/codex-cloud-meta-health.yml
@@ -196,6 +196,84 @@ jobs:
                 ["agent:queued", "agent:claimed", "agent:running", "agent:merge-gate"].includes(label.name)
               )
             );
+            const laneOrder = ["backend", "frontend", "quality", "security", "docs"];
+            const issueField = (issue, name) =>
+              (issue.body || "").match(new RegExp(`^${name}:\\s*(.+)$`, "im"))?.[1]?.toLowerCase() || "";
+            const labelNamesFor = (issue) => issue.labels.map((label) => label.name);
+            const inferIssueLane = (issue) => {
+              const explicitLane = issueField(issue, "Lane assignment");
+              if (laneOrder.includes(explicitLane)) return explicitLane;
+              const expectedFiles = issueField(issue, "Expected files");
+              if (
+                expectedFiles.includes(".github/") ||
+                expectedFiles.includes("dockerfile") ||
+                expectedFiles.includes("docker-compose") ||
+                expectedFiles.includes("package.json") ||
+                expectedFiles.includes("package-lock.json") ||
+                expectedFiles.includes("release/")
+              ) {
+                return "security";
+              }
+              if (
+                expectedFiles.includes("apps/controller/") ||
+                expectedFiles.includes("apps/worker/") ||
+                expectedFiles.includes("packages/shared/") ||
+                expectedFiles.includes("packages/github/")
+              ) {
+                return "backend";
+              }
+              if (expectedFiles.includes("apps/dashboard/")) return "frontend";
+              if (expectedFiles.includes("tests/") || expectedFiles.includes("playwright.config")) return "quality";
+              if (expectedFiles.includes("readme.md") || expectedFiles.includes("docs/")) return "docs";
+              const labeledLane = labelNamesFor(issue)
+                .find((label) => label.startsWith("lane:"))
+                ?.slice("lane:".length);
+              return laneOrder.includes(labeledLane) ? labeledLane : "";
+            };
+            const retryableBlockedIssues = openIssues
+              .filter((issue) => /^QUEUE_ITEM_READY:\s*yes\s*$/im.test(issue.body || ""))
+              .filter((issue) => {
+                const labels = labelNamesFor(issue);
+                return (
+                  labels.includes("agent:blocked") &&
+                  labels.includes("blocker:lane-stop") &&
+                  labels.includes("execution:codex-cloud")
+                );
+              })
+              .map((issue) => ({ issue, lane: inferIssueLane(issue) }))
+              .filter((item) => laneOrder.includes(item.lane))
+              .sort((a, b) => new Date(a.issue.created_at) - new Date(b.issue.created_at));
+
+            if (!openPrs.length && !queueIssues.length && retryableBlockedIssues.length) {
+              const { issue, lane } = retryableBlockedIssues[0];
+              const labels = labelNamesFor(issue);
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issue.number,
+                labels: ["agent:queued", `lane:${lane}`]
+              });
+              for (const label of labels.filter(
+                (name) =>
+                  ["agent:blocked", "blocker:lane-stop", "agent:claimed", "agent:running"].includes(name) ||
+                  (name.startsWith("lane:") && name !== `lane:${lane}`)
+              )) {
+                try {
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: issue.number, name: label });
+                } catch {}
+              }
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: `Meta Health requeued this recoverable lane-stop item for the ${lane} lane because there are no open PRs and no active queued/running agent issues.\n\nRun: ${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${context.runId}`
+              });
+              warnings.push({
+                class: "advisory",
+                title: `requeued blocked queue issue #${issue.number}`,
+                detail: `Issue #${issue.number} was returned to agent:queued for lane:${lane}.`
+              });
+            }
 
             let dependabotOpen = null;
             if (process.env.HAS_CODEX_HEALTH_TOKEN === "true") {
@@ -250,6 +328,7 @@ jobs:
               }`,
               `Open PRs: ${openPrs.length}`,
               `Open queued/running agent issues: ${queueIssues.length}`,
+              `Retryable blocked lane-stop issues: ${retryableBlockedIssues.length}`,
               `Open Dependabot alerts: ${dependabotOpen === null ? "unavailable" : dependabotOpen}`,
               "",
               blockers.length

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,26 @@ Optimize for safe convergence, not constant mutation.
 - Confirm branch sync before mutation.
 - Confirm no duplicate active PR scope.
 
+## Codex Cloud GitHub Actions
+
+- In `.github/workflows/codex-cloud-*`, GitHub issues, labels, and workflow
+  context are the control plane. Do not block only because local Windows Codex
+  state files under `C:\Users\burni\.codex` are unavailable in the cloud runner.
+- In Codex Cloud build stages, the workflow gate has already claimed the target
+  issue with GitHub labels. Respect that claim and write a clear blocked reason
+  only when the target scope is truly outside the assigned lane or verification
+  cannot run.
+- Resolve lanes in this order: explicit `Lane assignment:` in the issue body,
+  then `lane:*` labels, then workflow claim metadata. If no lane can be
+  resolved, block with `no lane assignment` instead of falling back to broad
+  keyword heuristics.
+- The checked-out GitHub Actions workspace is the branch-sync source. If
+  `git fetch --all --prune` cannot update `.git/FETCH_HEAD` inside the Codex
+  sandbox, do not treat that alone as a blocker. Instead, verify that
+  `git rev-parse HEAD` matches the expected commit SHA or that the required PR
+  refs exist for lane verification. If those minimal refs are missing, treat the
+  run as blocked.
+
 ## Verification
 
 - Run targeted checks after small changes.

--- a/apps/controller/src/store.ts
+++ b/apps/controller/src/store.ts
@@ -365,10 +365,11 @@ export class MemoryStore implements ControllerStore {
   }
 
   async listEvents(afterSequence = 0, limit = 50): Promise<AgentEvent[]> {
-    return this.events
-      .filter((event) => event.sequence > afterSequence)
-      .sort((a, b) => a.sequence - b.sequence)
-      .slice(0, limit);
+    const normalizedLimit = Math.max(0, limit);
+    const sorted = [...this.events].sort((a, b) => a.sequence - b.sequence);
+    if (normalizedLimit === 0) return [];
+    if (afterSequence <= 0) return sorted.slice(-normalizedLimit);
+    return sorted.filter((event) => event.sequence > afterSequence).slice(0, normalizedLimit);
   }
 
   async listMemories(workItemId?: string): Promise<MemoryRecord[]> {
@@ -980,15 +981,30 @@ export class PostgresStore extends MemoryStore {
   }
 
   override async listEvents(afterSequence = 0, limit = 50): Promise<AgentEvent[]> {
+    const normalizedLimit = Math.max(0, limit);
+    if (normalizedLimit === 0) return [];
+    if (afterSequence <= 0) {
+      const result = await this.pool.query(
+        `select payload from (
+           select payload, sequence from agent_events
+           order by sequence desc
+           limit $1
+         ) recent_events
+         order by sequence asc`,
+        [normalizedLimit]
+      );
+      const stored = result.rows.map((row) => AgentEventSchema.parse(row.payload));
+      return stored.length ? stored : super.listEvents(afterSequence, normalizedLimit);
+    }
     const result = await this.pool.query(
       `select payload from agent_events
        where sequence > $1
        order by sequence asc
        limit $2`,
-      [afterSequence, limit]
+      [afterSequence, normalizedLimit]
     );
     const stored = result.rows.map((row) => AgentEventSchema.parse(row.payload));
-    return stored.length ? stored : super.listEvents(afterSequence, limit);
+    return stored.length ? stored : super.listEvents(afterSequence, normalizedLimit);
   }
 
   override async claimWorkItemForWorkflow(id: string): Promise<boolean> {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,6 +35,13 @@ export default defineConfig({
       }
     },
     {
+      name: "chromium-desktop-1440",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 900 }
+      }
+    },
+    {
       name: "chromium-mobile-360",
       use: {
         ...devices["Pixel 5"],

--- a/tests/e2e/dashboard-smoke.spec.ts
+++ b/tests/e2e/dashboard-smoke.spec.ts
@@ -1,4 +1,64 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Request } from "@playwright/test";
+
+function createStatus(emergencyStop = false) {
+  return {
+    system: {
+      name: "AI Dev Team Controller",
+      operational: true,
+      emergencyStop,
+      queueDepth: 1,
+      agentsOnline: 5,
+      agentsTotal: 5,
+      githubSync: "synced",
+      systemLoad: 0.2,
+      emergencyReason: emergencyStop ? "[global] Operator dashboard control" : "",
+      scheduler: {
+        maxConcurrentAgentRuns: 5
+      }
+    },
+    pipeline: {
+      INTAKE: 0,
+      RND: 0,
+      PROPOSAL: 0,
+      ARCHITECTURE_REVIEW: 0,
+      BACKEND_BUILD: 0,
+      FRONTEND_BUILD: 0,
+      INTEGRATION: 0,
+      VERIFY: 1,
+      RELEASE: 0,
+      CLOSED: 0,
+      BLOCKED: 0
+    },
+    projectTeams: [],
+    workItems: [],
+    artifacts: [],
+    releaseReadiness: {
+      status: "ready",
+      target: "Local verification",
+      checks: []
+    },
+    logs: [],
+    sharedContext: {
+      activeThreads: [],
+      research: []
+    }
+  };
+}
+
+function readEmergencyPayload(request: Request) {
+  let payload: unknown;
+  try {
+    payload = request.postDataJSON();
+  } catch {
+    return null;
+  }
+
+  if (!payload || typeof payload !== "object") return null;
+  const { scope, reason } = payload as Record<string, unknown>;
+  if (typeof scope !== "string" || !scope.trim()) return null;
+  if (typeof reason !== "string" || !reason.trim()) return null;
+  return { scope, reason };
+}
 
 test.describe("dashboard smoke", () => {
   test("loads the operator dashboard without viewport overflow", async ({ page }) => {
@@ -73,5 +133,99 @@ test.describe("dashboard smoke", () => {
 
     expect(Math.max(viewport.scrollWidth, viewport.bodyScrollWidth)).toBeLessThanOrEqual(viewport.clientWidth + 2);
     expect(consoleErrors).toEqual([]);
+  });
+
+  test("posts emergency stop and resume controls", async ({ page }) => {
+    let emergencyStop = false;
+    const postedPaths: string[] = [];
+
+    await page.route("http://127.0.0.1:4310/api/**", async (route) => {
+      const url = new URL(route.request().url());
+      const request = route.request();
+      const jsonHeaders = {
+        "access-control-allow-origin": "*",
+        "content-type": "application/json"
+      };
+
+      if (url.pathname === "/api/status") {
+        await route.fulfill({
+          status: 200,
+          headers: jsonHeaders,
+          body: JSON.stringify(createStatus(emergencyStop))
+        });
+        return;
+      }
+      if (url.pathname === "/api/memories" || url.pathname === "/api/projects") {
+        await route.fulfill({ status: 200, headers: jsonHeaders, body: "[]" });
+        return;
+      }
+      if (url.pathname === "/api/github/account") {
+        await route.fulfill({
+          status: 200,
+          headers: jsonHeaders,
+          body: JSON.stringify({
+            connected: false,
+            source: "none",
+            scopes: [],
+            utilities: [],
+            clientIdConfigured: false,
+            message: "Not connected"
+          })
+        });
+        return;
+      }
+      if (request.method() === "POST" && url.pathname === "/api/emergency-stop") {
+        const payload = readEmergencyPayload(request);
+        if (!payload) {
+          await route.fulfill({
+            status: 400,
+            headers: jsonHeaders,
+            body: JSON.stringify({ error: "missing emergency scope or reason" })
+          });
+          return;
+        }
+        postedPaths.push(url.pathname);
+        emergencyStop = true;
+        await route.fulfill({
+          status: 200,
+          headers: jsonHeaders,
+          body: JSON.stringify({ emergencyStop: true, ...payload })
+        });
+        return;
+      }
+      if (request.method() === "POST" && url.pathname === "/api/emergency-resume") {
+        const payload = readEmergencyPayload(request);
+        if (!payload) {
+          await route.fulfill({
+            status: 400,
+            headers: jsonHeaders,
+            body: JSON.stringify({ error: "missing emergency scope or reason" })
+          });
+          return;
+        }
+        postedPaths.push(url.pathname);
+        emergencyStop = false;
+        await route.fulfill({
+          status: 200,
+          headers: jsonHeaders,
+          body: JSON.stringify({ emergencyStop: false, ...payload })
+        });
+        return;
+      }
+
+      await route.fulfill({ status: 404, headers: jsonHeaders, body: JSON.stringify({ error: "not found" }) });
+    });
+
+    await page.goto("/");
+
+    const emergencyToggle = page.getByTestId("emergency-toggle");
+    await expect(emergencyToggle).toHaveText(/Stop/);
+    await emergencyToggle.click();
+    await expect(emergencyToggle).toHaveText(/Resume/);
+    await expect(page.getByRole("status")).toContainText("Operator dashboard control");
+
+    await emergencyToggle.click();
+    await expect(emergencyToggle).toHaveText(/Stop/);
+    expect(postedPaths).toEqual(["/api/emergency-stop", "/api/emergency-resume"]);
   });
 });

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -67,6 +67,27 @@ async function expectOpportunityScanRunsNewestFirst(store: ControllerStore, repo
   await expect(store.listOpportunityScanRuns(scope)).resolves.toEqual([running, newer, updatedOlder]);
 }
 
+async function expectLatestEventBackfill(store: ControllerStore, workItemPrefix = "WI-EVENT") {
+  const events = [];
+
+  for (let index = 1; index <= 60; index += 1) {
+    events.push(
+      await store.addEvent({
+        workItemId: `${workItemPrefix}-${index}`,
+        stage: "VERIFY",
+        ownerAgent: "quality-security-privacy-release",
+        level: "info",
+        type: "stage_completed",
+        message: `Event ${index}`
+      })
+    );
+  }
+
+  await expect(store.listEvents(0, 50)).resolves.toEqual(events.slice(10));
+  await expect(store.listEvents(events[54].sequence, 10)).resolves.toEqual(events.slice(55));
+  await expect(store.listEvents(0, 0)).resolves.toEqual([]);
+}
+
 describe("controller store workflow claims", () => {
   it("prevents duplicate workflow claims for the same item", async () => {
     const store = new MemoryStore();
@@ -100,6 +121,11 @@ describe("controller store workflow claims", () => {
 
     expect(second.sequence).toBe(first.sequence + 1);
     await expect(store.listEvents(first.sequence, 10)).resolves.toEqual([second]);
+  });
+
+  it("returns the latest event backfill in ascending sequence order", async () => {
+    const store = new MemoryStore();
+    await expectLatestEventBackfill(store);
   });
 
   it("keeps project connections isolated and allows one team per repo", async () => {
@@ -232,6 +258,21 @@ describe("controller store workflow claims", () => {
       try {
         await store.init();
         await expectOpportunityScanRunsNewestFirst(store, `repo-scan-runs-${process.pid}-${Date.now()}`);
+      } finally {
+        await store.close();
+      }
+    }
+  );
+
+  it.skipIf(!process.env.POSTGRES_TEST_DATABASE_URL)(
+    "returns the latest event backfill in ascending sequence order in Postgres",
+    async () => {
+      const connectionString = process.env.POSTGRES_TEST_DATABASE_URL;
+      if (!connectionString) throw new Error("POSTGRES_TEST_DATABASE_URL is required for this test.");
+      const store = new PostgresStore(connectionString);
+      try {
+        await store.init();
+        await expectLatestEventBackfill(store, `WI-EVENT-PG-${process.pid}-${Date.now()}`);
       } finally {
         await store.close();
       }


### PR DESCRIPTION
## Summary

- fixes cloud queue lane inference to trust the issue's explicit Lane assignment before broad keyword heuristics
- adds cloud-specific AGENTS guidance so Codex Action does not block on unavailable local Windows state or read-only FETCH_HEAD
- installs Playwright system dependencies before the Codex sandbox drops sudo, and preserves Codex output in blocked issue comments
- lets Meta Health requeue one recoverable lane-stop item when no PR or active queue item is present
- fixes event stream initial backfill to return the latest events in ascending order
- adds 1440px dashboard smoke coverage and emergency stop/resume e2e coverage

## Validation

- npm test -- tests/store.test.ts
- npm run typecheck
- npm run lint
- npm run format:check
- git diff --check
- docker compose config --no-interpolate --quiet
- npm run test:e2e -- tests/e2e/dashboard-smoke.spec.ts
- npm run check
- npm run logs:check
- npm run diff:budget
- npm run automation:verify-paused
- CodeRabbit CLI review: 0 issues

Closes #49
Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a larger desktop test viewport for broader UI coverage.
  * Issue comments can optionally include a truncated tool output snippet for clearer feedback.

* **Bug Fixes**
  * Fixed event ordering and pagination in storage.
  * Improved CI lane recovery to requeue blocked issues and report counts.

* **Documentation**
  * Clarified Codex Cloud workflow control-plane and branch-sync guidance.

* **Tests**
  * Added dashboard emergency stop/resume e2e test.
  * Added event storage pagination tests.

* **Chores**
  * Optimized CI build steps and Playwright dependency handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->