### PR TITLE
Codex Cloud Backend/Core: [Codex Queue] Scaffold `.agent-team` on project connect

### DIFF
--- a/apps/controller/src/index.ts
+++ b/apps/controller/src/index.ts
@@ -25,6 +25,7 @@ import {
   EmergencyControlRequestSchema,
   ProjectCapabilityStatusSchema,
   ProjectConnectionInputSchema,
+  ProjectConnectionSchema,
   OpportunityScanRunSchema,
   ReleaseClassSchema,
   WorkItemStateSchema,
@@ -837,9 +838,10 @@ app.post("/api/projects", async (req, res, next) => {
   try {
     const input = ProjectConnectionInputSchema.parse(req.body);
     const diagnostics = await inspectProjectConnection(input);
+    const candidate = buildProjectConnectionCandidate(input, diagnostics);
+    await scaffoldAgentTeam(candidate.localPath);
+    if (candidate.active) await writeTargetRepoConfig(candidate);
     const project = await store.upsertProjectConnection({ ...input, ...diagnostics });
-    await scaffoldAgentTeam(project.localPath);
-    if (project.active) await writeTargetRepoConfig(project);
     await store.addEvent({
       level: project.status === "connected" ? "info" : "warn",
       type: "system",
@@ -853,11 +855,13 @@ app.post("/api/projects", async (req, res, next) => {
 
 app.post("/api/projects/:id/activate", async (req, res, next) => {
   try {
-    const activated = await store.activateProjectConnection(req.params.id);
-    const diagnostics = await inspectProjectConnection(activated);
-    const project = await store.upsertProjectConnection({ ...activated, active: true, ...diagnostics });
-    await scaffoldAgentTeam(project.localPath);
-    await writeTargetRepoConfig(project);
+    const current = await requireProjectConnection(req.params.id);
+    const activeInput = ProjectConnectionInputSchema.parse({ ...current, active: true });
+    const diagnostics = await inspectProjectConnection(activeInput);
+    const candidate = buildProjectConnectionCandidate(activeInput, diagnostics, current.createdAt);
+    await scaffoldAgentTeam(candidate.localPath);
+    await writeTargetRepoConfig(candidate);
+    const project = await store.upsertProjectConnection({ ...activeInput, ...diagnostics });
     await store.addEvent({
       level: project.status === "connected" ? "info" : "warn",
       type: "system",
@@ -943,6 +947,37 @@ async function writeTargetRepoConfig(project: ProjectConnection): Promise<void> 
   const projectConfigDir = process.env.AGENT_TEAM_PROJECT_CONFIG_DIR || ".agent-team/projects";
   await fs.mkdir(projectConfigDir, { recursive: true });
   await fs.writeFile(path.join(projectConfigDir, `${safeFileSegment(project.projectId)}.yaml`), yaml, "utf8");
+}
+
+function buildProjectConnectionCandidate(
+  input: ProjectConnectionInput,
+  diagnostics: ProjectConnectionDiagnostics,
+  createdAt = new Date().toISOString()
+): ProjectConnection {
+  const parsed = ProjectConnectionInputSchema.parse(input);
+  const projectId = parsed.projectId || safeFileSegment(`${parsed.repoOwner}-${parsed.repoName}`);
+  const repo = `${parsed.repoOwner}/${parsed.repoName}`;
+  return ProjectConnectionSchema.parse({
+    ...parsed,
+    ...diagnostics,
+    id: projectId,
+    projectId,
+    name: parsed.name || repo,
+    repo,
+    memoryNamespace: projectId,
+    contextDir: ".agent-team/context",
+    status: diagnostics.status || (parsed.active ? "connected" : "inactive"),
+    capabilities: diagnostics.capabilities || [],
+    validationErrors: diagnostics.validationErrors || [],
+    createdAt,
+    updatedAt: new Date().toISOString()
+  });
+}
+
+async function requireProjectConnection(id: string): Promise<ProjectConnection> {
+  const project = (await store.listProjectConnections()).find((candidate) => candidate.id === id);
+  if (!project) throw new HttpError(`Project connection ${id} was not found.`, 404);
+  return project;
 }
 
 async function removeTargetRepoConfig(project: ProjectConnection): Promise<void> {

--- a/apps/controller/src/index.ts
+++ b/apps/controller/src/index.ts
@@ -43,6 +43,7 @@ import {
   githubTokenSource,
   writeStoredGitHubAuth
 } from "../../../packages/shared/src/github-auth";
+import { scaffoldAgentTeam } from "./scaffold";
 
 const CreateWorkItemRequest = z.object({
   title: z.string().min(1),
@@ -837,6 +838,7 @@ app.post("/api/projects", async (req, res, next) => {
     const input = ProjectConnectionInputSchema.parse(req.body);
     const diagnostics = await inspectProjectConnection(input);
     const project = await store.upsertProjectConnection({ ...input, ...diagnostics });
+    await scaffoldAgentTeam(project.localPath);
     if (project.active) await writeTargetRepoConfig(project);
     await store.addEvent({
       level: project.status === "connected" ? "info" : "warn",
@@ -854,6 +856,7 @@ app.post("/api/projects/:id/activate", async (req, res, next) => {
     const activated = await store.activateProjectConnection(req.params.id);
     const diagnostics = await inspectProjectConnection(activated);
     const project = await store.upsertProjectConnection({ ...activated, active: true, ...diagnostics });
+    await scaffoldAgentTeam(project.localPath);
     await writeTargetRepoConfig(project);
     await store.addEvent({
       level: project.status === "connected" ? "info" : "warn",

--- a/apps/controller/src/scaffold.ts
+++ b/apps/controller/src/scaffold.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const TEMPLATE_AGENT_TEAM_ROOT = path.resolve(process.cwd(), "templates", "target-repo", ".agent-team");
+
+type ScaffoldFile = {
+  source: string;
+  target: string;
+  mode?: number;
+};
+
+export async function scaffoldAgentTeam(localPath: string): Promise<void> {
+  if (!localPath) return;
+  const repoStat = await fs.stat(localPath).catch(() => null);
+  if (!repoStat?.isDirectory()) return;
+
+  const targetRoot = path.join(localPath, ".agent-team");
+  const files: ScaffoldFile[] = [
+    {
+      source: path.join(TEMPLATE_AGENT_TEAM_ROOT, "context", "TEAM_RULES.md"),
+      target: path.join(targetRoot, "context", "TEAM_RULES.md")
+    },
+    {
+      source: path.join(TEMPLATE_AGENT_TEAM_ROOT, "hooks", "pre-push"),
+      target: path.join(targetRoot, "hooks", "pre-push"),
+      mode: 0o755
+    }
+  ];
+
+  for (const file of files) {
+    if (await exists(file.target)) continue;
+    await fs.mkdir(path.dirname(file.target), { recursive: true });
+    await fs.copyFile(file.source, file.target);
+    if (file.mode && process.platform !== "win32") {
+      await fs.chmod(file.target, file.mode);
+    }
+  }
+}
+
+async function exists(target: string): Promise<boolean> {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/controller/src/scaffold.ts
+++ b/apps/controller/src/scaffold.ts
@@ -1,7 +1,8 @@
+import { constants, existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 
-const TEMPLATE_AGENT_TEAM_ROOT = path.resolve(process.cwd(), "templates", "target-repo", ".agent-team");
+const TEMPLATE_AGENT_TEAM_ROOT = resolveTemplateRoot();
 
 type ScaffoldFile = {
   source: string;
@@ -28,20 +29,27 @@ export async function scaffoldAgentTeam(localPath: string): Promise<void> {
   ];
 
   for (const file of files) {
-    if (await exists(file.target)) continue;
     await fs.mkdir(path.dirname(file.target), { recursive: true });
-    await fs.copyFile(file.source, file.target);
+    try {
+      await fs.copyFile(file.source, file.target, constants.COPYFILE_EXCL);
+    } catch (error) {
+      if (isNodeError(error) && error.code === "EEXIST") continue;
+      throw error;
+    }
     if (file.mode && process.platform !== "win32") {
       await fs.chmod(file.target, file.mode);
     }
   }
 }
 
-async function exists(target: string): Promise<boolean> {
-  try {
-    await fs.access(target);
-    return true;
-  } catch {
-    return false;
-  }
+function resolveTemplateRoot(): string {
+  const candidates = [
+    path.resolve(__dirname, "..", "..", "..", "templates", "target-repo", ".agent-team"),
+    path.resolve(__dirname, "..", "..", "..", "..", "templates", "target-repo", ".agent-team")
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) || candidates[0];
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
 }

--- a/tests/agent-team-scaffold.test.ts
+++ b/tests/agent-team-scaffold.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { scaffoldAgentTeam } from "../apps/controller/src/scaffold";
 
 describe("agent-team scaffolding", () => {
   it("creates missing files without overwriting existing ones", async () => {
-    const root = join(tmpdir(), `agent-team-${process.pid}-${Date.now()}`);
+    const root = mkdtempSync(join(tmpdir(), "agent-team-"));
     const repo = join(root, "repo");
     const templateRoot = join(process.cwd(), "templates", "target-repo", ".agent-team");
     const templateRules = join(templateRoot, "context", "TEAM_RULES.md");
@@ -18,8 +18,6 @@ describe("agent-team scaffolding", () => {
       mkdirSync(repo, { recursive: true });
       await scaffoldAgentTeam(repo);
 
-      expect(existsSync(targetRules)).toBe(true);
-      expect(existsSync(targetHook)).toBe(true);
       expect(readFileSync(targetRules, "utf8")).toBe(readFileSync(templateRules, "utf8"));
       expect(readFileSync(targetHook, "utf8")).toBe(readFileSync(templateHook, "utf8"));
 

--- a/tests/agent-team-scaffold.test.ts
+++ b/tests/agent-team-scaffold.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scaffoldAgentTeam } from "../apps/controller/src/scaffold";
+
+describe("agent-team scaffolding", () => {
+  it("creates missing files without overwriting existing ones", async () => {
+    const root = join(tmpdir(), `agent-team-${process.pid}-${Date.now()}`);
+    const repo = join(root, "repo");
+    const templateRoot = join(process.cwd(), "templates", "target-repo", ".agent-team");
+    const templateRules = join(templateRoot, "context", "TEAM_RULES.md");
+    const templateHook = join(templateRoot, "hooks", "pre-push");
+    const targetRules = join(repo, ".agent-team", "context", "TEAM_RULES.md");
+    const targetHook = join(repo, ".agent-team", "hooks", "pre-push");
+
+    try {
+      mkdirSync(repo, { recursive: true });
+      await scaffoldAgentTeam(repo);
+
+      expect(existsSync(targetRules)).toBe(true);
+      expect(existsSync(targetHook)).toBe(true);
+      expect(readFileSync(targetRules, "utf8")).toBe(readFileSync(templateRules, "utf8"));
+      expect(readFileSync(targetHook, "utf8")).toBe(readFileSync(templateHook, "utf8"));
+
+      if (process.platform !== "win32") {
+        expect(statSync(targetHook).mode & 0o777).toBe(0o755);
+      }
+
+      writeFileSync(targetRules, "custom rules\n", "utf8");
+      writeFileSync(targetHook, "custom hook\n", "utf8");
+
+      await scaffoldAgentTeam(repo);
+
+      expect(readFileSync(targetRules, "utf8")).toBe("custom rules\n");
+      expect(readFileSync(targetHook, "utf8")).toBe("custom hook\n");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Codex Cloud Backend/Core implemented queued issue #53.

Closes #53

## Scope

[Codex Queue] Scaffold `.agent-team` on project connect

## Validation

- npm run check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- git diff --check

## Automation

- Stage: Backend/Core
- Run: https://github.com/onfire7777/five-agent-dev-team/actions/runs/25257860368
- Target: #53


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects now automatically initialize agent-team directories during creation and activation workflows, setting up required config files and commit hooks and preserving existing customizations.

* **Tests**
  * Added automated tests to verify scaffolding creates missing files, preserves preexisting files, and sets executable hook permissions on non‑Windows platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->