### PR TITLE
Add workflow recovery script

### DIFF
--- a/apps/controller/src/temporal.ts
+++ b/apps/controller/src/temporal.ts
@@ -1,5 +1,16 @@
-import { Connection, Client } from "@temporalio/client";
+import { Client, Connection, WorkflowNotFoundError } from "@temporalio/client";
 import type { WorkItem } from "../../../packages/shared/src";
+
+export type TemporalRecoveryAction = "cancel" | "terminate";
+
+export interface TemporalWorkflowRecoveryResult {
+  workflowId: string;
+  attempted: boolean;
+  recovered: boolean;
+  action: TemporalRecoveryAction;
+  reason: "cancelled" | "terminated" | "not_found" | "temporal_not_configured";
+  message: string;
+}
 
 export function workflowIdForWorkItem(workItem: WorkItem): string {
   if (!workItem.projectId) {
@@ -82,6 +93,81 @@ export async function signalProposalDecision(
   } catch (error) {
     console.warn("Temporal proposal decision signal skipped:", error instanceof Error ? error.message : error);
     return false;
+  } finally {
+    await connection?.close().catch(() => undefined);
+  }
+}
+
+export async function recoverAutonomousWorkflow(
+  workItem: WorkItem,
+  options: { action?: TemporalRecoveryAction; reason?: string } = {}
+): Promise<TemporalWorkflowRecoveryResult> {
+  const workflowId = workItem.projectId ? workflowIdForWorkItem(workItem) : `wi-unscoped-${workItem.id}`;
+  const action = options.action || "terminate";
+  const recoveryReason = options.reason || `Manual recovery requested for ${workItem.id}.`;
+  const address = process.env.TEMPORAL_ADDRESS;
+  if (!address) {
+    return {
+      workflowId,
+      attempted: false,
+      recovered: false,
+      action,
+      reason: "temporal_not_configured",
+      message: "TEMPORAL_ADDRESS is not configured; local workflow claim recovery can continue."
+    };
+  }
+  if (!workItem.projectId) {
+    return {
+      workflowId,
+      attempted: false,
+      recovered: false,
+      action,
+      reason: "not_found",
+      message: `Temporal workflow ${workflowId} cannot be resolved without projectId; local workflow claim recovery can continue.`
+    };
+  }
+
+  let connection: Connection | null = null;
+  try {
+    connection = await Connection.connect({ address });
+    const client = new Client({
+      connection,
+      namespace: process.env.TEMPORAL_NAMESPACE || "default"
+    });
+    const handle = client.workflow.getHandle(workflowId);
+    if (action === "cancel") {
+      await handle.cancel();
+      return {
+        workflowId,
+        attempted: true,
+        recovered: true,
+        action,
+        reason: "cancelled",
+        message: `Temporal workflow ${workflowId} was cancelled.`
+      };
+    }
+
+    await handle.terminate(recoveryReason);
+    return {
+      workflowId,
+      attempted: true,
+      recovered: true,
+      action,
+      reason: "terminated",
+      message: `Temporal workflow ${workflowId} was terminated.`
+    };
+  } catch (error) {
+    if (error instanceof WorkflowNotFoundError) {
+      return {
+        workflowId,
+        attempted: true,
+        recovered: false,
+        action,
+        reason: "not_found",
+        message: `Temporal workflow ${workflowId} was not found; local workflow claim recovery can continue.`
+      };
+    }
+    throw error;
   } finally {
     await connection?.close().catch(() => undefined);
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "automation:verify-paused": "node scripts/bulk-automation-status.mjs --expect-status=PAUSED",
     "automation:verify-active": "node scripts/bulk-automation-status.mjs --expect-status=ACTIVE",
     "ops:janitor": "node scripts/janitor.mjs",
+    "recover:workflow": "tsx scripts/recover-workflow.ts",
     "logs:check": "node scripts/validate-logging.mjs",
     "spec:hash": "node scripts/spec-hash.mjs",
     "diff:budget": "node scripts/diff-budget-check.mjs"

--- a/scripts/recover-workflow.ts
+++ b/scripts/recover-workflow.ts
@@ -1,0 +1,119 @@
+import { createStore, type ControllerStore } from "../apps/controller/src/store";
+import { isTerminalWorkItemState, type AgentEvent, type WorkItem, type WorkItemState } from "../packages/shared/src";
+import {
+  recoverAutonomousWorkflow,
+  type TemporalRecoveryAction,
+  type TemporalWorkflowRecoveryResult
+} from "../apps/controller/src/temporal";
+
+export interface WorkflowRecoveryResult {
+  workItemId: string;
+  previousState: WorkItemState;
+  currentState: WorkItemState;
+  claimReleased: boolean;
+  stateChanged: boolean;
+  temporal: TemporalWorkflowRecoveryResult;
+  event: AgentEvent;
+}
+
+export interface RecoverWorkflowOptions {
+  workItemId: string;
+  reason?: string;
+  action?: TemporalRecoveryAction;
+  store?: ControllerStore;
+  temporalRecover?: (
+    workItem: WorkItem,
+    options: { action?: TemporalRecoveryAction; reason?: string }
+  ) => Promise<TemporalWorkflowRecoveryResult>;
+}
+
+export async function recoverWorkflow(options: RecoverWorkflowOptions): Promise<WorkflowRecoveryResult> {
+  const store = options.store || createStore();
+  await store.init();
+
+  const record = await store.getWorkItemWithArtifacts(options.workItemId);
+  if (!record) throw new Error(`Work item ${options.workItemId} was not found.`);
+
+  const reason = options.reason || `Workflow recovery requested for ${record.workItem.id}.`;
+  const temporal = await (options.temporalRecover || recoverAutonomousWorkflow)(record.workItem, {
+    action: options.action,
+    reason
+  });
+  await store.releaseWorkItemWorkflowClaim(record.workItem.id);
+
+  let currentState = record.workItem.state;
+  let stateChanged = false;
+  if (!isTerminalWorkItemState(record.workItem.state)) {
+    await store.updateWorkItemState(record.workItem.id, "BLOCKED");
+    currentState = "BLOCKED";
+    stateChanged = true;
+  }
+
+  const event = await store.addEvent({
+    workItemId: record.workItem.id,
+    stage: currentState,
+    level: stateChanged ? "warn" : "info",
+    type: "system",
+    message: [
+      `Workflow recovery completed for ${record.workItem.id}.`,
+      `Temporal result: ${temporal.reason}.`,
+      stateChanged ? "Work item moved to BLOCKED for operator review." : "Work item was already terminal."
+    ].join(" ")
+  });
+
+  return {
+    workItemId: record.workItem.id,
+    previousState: record.workItem.state,
+    currentState,
+    claimReleased: true,
+    stateChanged,
+    temporal,
+    event
+  };
+}
+
+if (require.main === module) {
+  const workItemId = argValue("--work-item") || argValue("--workItem") || process.argv[2];
+  if (!workItemId || workItemId.startsWith("--")) {
+    console.error(
+      "Usage: npm run recover:workflow -- --work-item <WORK_ITEM_ID> [--action cancel|terminate] [--reason text]"
+    );
+    process.exit(1);
+  }
+
+  let action: TemporalRecoveryAction | undefined;
+  try {
+    action = parseAction(argValue("--action"));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+
+  recoverWorkflow({
+    workItemId,
+    action,
+    reason: argValue("--reason")
+  })
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+    })
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    });
+}
+
+function parseAction(value: string | undefined): TemporalRecoveryAction | undefined {
+  if (!value) return undefined;
+  if (value === "cancel" || value === "terminate") return value;
+  throw new Error(`Unsupported recovery action ${value}. Use cancel or terminate.`);
+}
+
+function argValue(name: string): string | undefined {
+  const inline = process.argv.find((arg) => arg.startsWith(`${name}=`));
+  if (inline) return inline.slice(name.length + 1);
+  const index = process.argv.indexOf(name);
+  if (index < 0) return undefined;
+  const value = process.argv[index + 1];
+  return value && !value.startsWith("--") ? value : undefined;
+}

--- a/tests/recover-workflow.test.ts
+++ b/tests/recover-workflow.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import { MemoryStore } from "../apps/controller/src/store";
+import { recoverAutonomousWorkflow, type TemporalWorkflowRecoveryResult } from "../apps/controller/src/temporal";
+import { recoverWorkflow } from "../scripts/recover-workflow";
+import { WorkItemSchema, type WorkItem } from "../packages/shared/src";
+
+describe("workflow recovery", () => {
+  it("releases the workflow claim and blocks a non-terminal work item", async () => {
+    const store = new MemoryStore();
+    await store.upsertProjectConnection({
+      repoOwner: "owner",
+      repoName: "repo",
+      localPath: "C:/repos/repo",
+      active: true
+    });
+    const workItem = await store.createWorkItem({
+      title: "Stuck workflow",
+      requestType: "bug",
+      priority: "high",
+      dependencies: [],
+      acceptanceCriteria: [],
+      riskLevel: "medium",
+      frontendNeeded: false,
+      backendNeeded: true,
+      rndNeeded: false,
+      projectId: "owner-repo",
+      repo: "owner/repo"
+    });
+    await store.claimWorkItemForWorkflow(workItem.id);
+
+    const result = await recoverWorkflow({
+      store,
+      workItemId: workItem.id,
+      temporalRecover: temporalNotConfigured
+    });
+
+    expect(result).toMatchObject({
+      workItemId: workItem.id,
+      previousState: "NEW",
+      currentState: "BLOCKED",
+      claimReleased: true,
+      stateChanged: true,
+      temporal: { reason: "temporal_not_configured" }
+    });
+    await expect(store.listWorkflowClaims()).resolves.toEqual([]);
+    await expect(store.getWorkItemWithArtifacts(workItem.id)).resolves.toMatchObject({
+      workItem: { state: "BLOCKED" }
+    });
+    await expect(store.listEvents(0, 10)).resolves.toEqual([
+      expect.objectContaining({
+        workItemId: workItem.id,
+        level: "warn",
+        type: "system",
+        message: expect.stringContaining("Workflow recovery completed")
+      })
+    ]);
+  });
+
+  it("releases claims without changing already-terminal work items", async () => {
+    const store = new MemoryStore();
+    await store.upsertProjectConnection({
+      repoOwner: "owner",
+      repoName: "repo",
+      localPath: "C:/repos/repo",
+      active: true
+    });
+    const workItem = await store.createWorkItem({
+      title: "Already blocked",
+      requestType: "bug",
+      priority: "medium",
+      dependencies: [],
+      acceptanceCriteria: [],
+      riskLevel: "medium",
+      frontendNeeded: false,
+      backendNeeded: true,
+      rndNeeded: false,
+      projectId: "owner-repo",
+      repo: "owner/repo"
+    });
+    await store.updateWorkItemState(workItem.id, "BLOCKED");
+    await store.claimWorkItemForWorkflow(workItem.id);
+
+    const result = await recoverWorkflow({
+      store,
+      workItemId: workItem.id,
+      temporalRecover: temporalNotFound
+    });
+
+    expect(result).toMatchObject({
+      previousState: "BLOCKED",
+      currentState: "BLOCKED",
+      stateChanged: false,
+      temporal: { reason: "not_found" }
+    });
+    await expect(store.listWorkflowClaims()).resolves.toEqual([]);
+    await expect(store.getWorkItemWithArtifacts(workItem.id)).resolves.toMatchObject({
+      workItem: { state: "BLOCKED" }
+    });
+  });
+
+  it("passes cancel recovery results through the workflow recovery path", async () => {
+    const store = new MemoryStore();
+    await store.upsertProjectConnection({
+      repoOwner: "owner",
+      repoName: "repo",
+      localPath: "C:/repos/repo",
+      active: true
+    });
+    const workItem = await store.createWorkItem({
+      title: "Cancel stuck workflow",
+      requestType: "bug",
+      priority: "medium",
+      dependencies: [],
+      acceptanceCriteria: [],
+      riskLevel: "medium",
+      frontendNeeded: false,
+      backendNeeded: true,
+      rndNeeded: false,
+      projectId: "owner-repo",
+      repo: "owner/repo"
+    });
+    await store.claimWorkItemForWorkflow(workItem.id);
+
+    const result = await recoverWorkflow({
+      store,
+      workItemId: workItem.id,
+      temporalRecover: temporalCancelled
+    });
+
+    expect(result).toMatchObject({
+      workItemId: workItem.id,
+      currentState: "BLOCKED",
+      claimReleased: true,
+      stateChanged: true,
+      temporal: {
+        workflowId: `wi-owner-repo-${workItem.id}`,
+        attempted: true,
+        recovered: true,
+        action: "cancel",
+        reason: "cancelled",
+        message: "Temporal workflow was cancelled."
+      }
+    });
+    await expect(store.listWorkflowClaims()).resolves.toEqual([]);
+    await expect(store.getWorkItemWithArtifacts(workItem.id)).resolves.toMatchObject({
+      workItem: { state: "BLOCKED" }
+    });
+  });
+
+  it("allows local recovery to continue for legacy unscoped work items", async () => {
+    const previousAddress = process.env.TEMPORAL_ADDRESS;
+    delete process.env.TEMPORAL_ADDRESS;
+    try {
+      const workItem = WorkItemSchema.parse({
+        id: "WI-LEGACY",
+        title: "Legacy work",
+        requestType: "bug",
+        priority: "medium",
+        state: "NEW",
+        dependencies: [],
+        acceptanceCriteria: [],
+        riskLevel: "medium",
+        frontendNeeded: false,
+        backendNeeded: true,
+        rndNeeded: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      });
+
+      await expect(recoverAutonomousWorkflow(workItem)).resolves.toMatchObject({
+        workflowId: "wi-unscoped-WI-LEGACY",
+        attempted: false,
+        recovered: false,
+        reason: "temporal_not_configured"
+      });
+    } finally {
+      if (previousAddress === undefined) delete process.env.TEMPORAL_ADDRESS;
+      else process.env.TEMPORAL_ADDRESS = previousAddress;
+    }
+  });
+});
+
+async function temporalNotConfigured(workItem: WorkItem): Promise<TemporalWorkflowRecoveryResult> {
+  return {
+    workflowId: `wi-${workItem.projectId}-${workItem.id}`,
+    attempted: false,
+    recovered: false,
+    action: "terminate",
+    reason: "temporal_not_configured",
+    message: "TEMPORAL_ADDRESS is not configured."
+  };
+}
+
+async function temporalNotFound(workItem: WorkItem): Promise<TemporalWorkflowRecoveryResult> {
+  return {
+    workflowId: `wi-${workItem.projectId}-${workItem.id}`,
+    attempted: true,
+    recovered: false,
+    action: "terminate",
+    reason: "not_found",
+    message: "Temporal workflow was not found."
+  };
+}
+
+async function temporalCancelled(workItem: WorkItem): Promise<TemporalWorkflowRecoveryResult> {
+  return {
+    workflowId: `wi-${workItem.projectId}-${workItem.id}`,
+    attempted: true,
+    recovered: true,
+    action: "cancel",
+    reason: "cancelled",
+    message: "Temporal workflow was cancelled."
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "rootDir": ".",
     "types": ["node", "vitest/globals"]
   },
-  "include": ["apps/**/*.ts", "apps/**/*.tsx", "packages/**/*.ts", "tests/**/*.ts"],
+  "include": ["apps/**/*.ts", "apps/**/*.tsx", "packages/**/*.ts", "scripts/**/*.ts", "tests/**/*.ts"],
   "exclude": ["dist", "node_modules", "apps/dashboard/vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- add a Temporal workflow recovery helper that can cancel or terminate stuck workflows and treats missing workflows as safe to continue local recovery
- add a typed recovery CLI (`npm run recover:workflow -- --work-item <id>`) that releases workflow claims, blocks non-terminal work items, and records a system event
- add regression tests for recovering stuck non-terminal work and already-terminal work items

## Validation
- npm test -- tests/recover-workflow.test.ts
- npm run check
- npm run logs:check
- npm run diff:budget
- docker compose config --no-interpolate --quiet
- git diff --check

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual autonomous workflow recovery with cancel/terminate options and clear result statuses (e.g., temporal not configured, not found, cancelled, terminated).
  * New CLI command to run workflow recovery, release workflow claims, and emit structured recovery output.

* **Tests**
  * Added tests covering recovery flows, state transitions, claim handling, and error/edge cases.

* **Chores**
  * TypeScript build scope expanded to include project scripts; new npm script to run the recovery CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->