### PR TITLE
Gate Codex research actor before action run

### DIFF
--- a/.github/workflows/codex-cloud-research.yml
+++ b/.github/workflows/codex-cloud-research.yml
@@ -40,6 +40,15 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const force = context.payload.inputs?.force === "true" || context.payload.inputs?.force === true;
+            const allowedActors = new Set(["onfire7777"]);
+
+            if (context.eventName === "workflow_dispatch" && !allowedActors.has(context.actor)) {
+              return JSON.stringify({
+                run: false,
+                reason: `skipped: actor=${context.actor} is not allowed to run openai/codex-action`
+              });
+            }
+
             const openPrs = await github.paginate(github.rest.pulls.list, {
               owner,
               repo,


### PR DESCRIPTION
## Summary

Fixes the post-merge Codex Cloud Research failure where github-actions[bot] dispatches the workflow but openai/codex-action rejects the actor for lacking repository write access.

## Changes

- Adds an explicit actor gate before checkout/context preparation/Codex action execution.
- Bot-dispatched research runs now exit as clean no-op runs instead of red failed workflow runs.
- Human/manual and scheduled runs by onfire7777 remain eligible.

## Validation

- 
pm run check
- workflow YAML parse via yaml
- 
pm run logs:check
- docker compose config --no-interpolate --quiet
- git diff --check

Fixes current cloud research run failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal CI workflow to add an allowlist check that blocks manual workflow dispatches from unauthorized actors before other eligibility checks, tightening gatekeeping and execution controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->