### PR TITLE
Codex Cloud Backend/Core: [Codex Queue] Write/read per-project `.agent-team/config.yaml` in target repo

### DIFF
--- a/apps/controller/src/index.ts
+++ b/apps/controller/src/index.ts
@@ -944,6 +944,9 @@ async function writeTargetRepoConfig(project: ProjectConnection): Promise<void> 
   const config = targetRepoConfigFromProjectConnection(project);
   const yaml = YAML.stringify(config);
   await fs.writeFile(process.env.AGENT_TEAM_CONFIG || "agent-team.config.yaml", yaml, "utf8");
+  const targetRepoConfigDir = path.join(project.localPath, ".agent-team");
+  await fs.mkdir(targetRepoConfigDir, { recursive: true });
+  await fs.writeFile(path.join(targetRepoConfigDir, "config.yaml"), yaml, "utf8");
   const projectConfigDir = process.env.AGENT_TEAM_PROJECT_CONFIG_DIR || ".agent-team/projects";
   await fs.mkdir(projectConfigDir, { recursive: true });
   await fs.writeFile(path.join(projectConfigDir, `${safeFileSegment(project.projectId)}.yaml`), yaml, "utf8");

--- a/apps/worker/src/activities.ts
+++ b/apps/worker/src/activities.ts
@@ -16,6 +16,7 @@ import {
   targetConfigMatchesWorkItem,
   targetRepoConfigFromProjectConnection,
   githubAuthEnv,
+  type ProjectConnection,
   type StageArtifact,
   type TargetRepoConfig,
   type VerificationSignal,
@@ -1426,6 +1427,8 @@ function createDefaultReleaseConfig(): TargetRepoConfig {
 async function loadReleaseConfig(workItem?: WorkItem): Promise<TargetRepoConfig> {
   const configPath = process.env.AGENT_TEAM_CONFIG || "agent-team.config.yaml";
   try {
+    const targetRepoFileConfig = workItem ? await loadConfigFromTargetRepoFile(workItem) : null;
+    if (targetRepoFileConfig) return targetRepoFileConfig;
     const projectFileConfig = workItem ? await loadConfigFromProjectFile(workItem) : null;
     if (projectFileConfig) return projectFileConfig;
     const config = loadTargetRepoConfig(configPath);
@@ -1458,7 +1461,7 @@ async function loadReleaseConfig(workItem?: WorkItem): Promise<TargetRepoConfig>
   }
 }
 
-async function loadConfigFromProjectConnection(workItem: WorkItem): Promise<TargetRepoConfig | null> {
+async function findProjectConnectionForWorkItem(workItem: WorkItem): Promise<ProjectConnection | null> {
   const store = await getActivityStore();
   const connections = await store.listProjectConnections();
   const match = connections.find((connection) => {
@@ -1467,6 +1470,25 @@ async function loadConfigFromProjectConnection(workItem: WorkItem): Promise<Targ
       return connection.projectId === workItem.projectId && connection.repo === workItem.repo;
     return connection.projectId === workItem.projectId || connection.repo === workItem.repo;
   });
+  return match || null;
+}
+
+async function loadConfigFromTargetRepoFile(workItem: WorkItem): Promise<TargetRepoConfig | null> {
+  const match = await findProjectConnectionForWorkItem(workItem);
+  if (!match?.localPath) return null;
+  const configPath = path.join(match.localPath, ".agent-team", "config.yaml");
+  try {
+    const config = loadTargetRepoConfig(configPath);
+    if (targetConfigMatchesWorkItem(config, workItem)) return config;
+    throw new Error(`Target repo config ${configPath} does not match ${workItem.projectId || workItem.repo}.`);
+  } catch (error) {
+    if (error instanceof Error && /does not match/.test(error.message)) throw error;
+    return null;
+  }
+}
+
+async function loadConfigFromProjectConnection(workItem: WorkItem): Promise<TargetRepoConfig | null> {
+  const match = await findProjectConnectionForWorkItem(workItem);
   return match ? targetRepoConfigFromProjectConnection(match) : null;
 }
 


### PR DESCRIPTION
## Summary

Codex Cloud Backend/Core implemented queued issue #59.

Closes #59

## Scope

[Codex Queue] Write/read per-project `.agent-team/config.yaml` in target repo

## Validation

- npm run check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- git diff --check

## Automation

- Stage: Backend/Core
- Run: https://github.com/onfire7777/five-agent-dev-team/actions/runs/25259156097
- Target: #59


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Configuration files are now stored in per-project directories for better organization.
  * Configuration loading prioritizes project-specific settings when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->