### PR TITLE
Backend: write/read target repo agent-team config

### DIFF
--- a/apps/controller/src/index.ts
+++ b/apps/controller/src/index.ts
@@ -987,6 +987,18 @@ async function removeTargetRepoConfig(project: ProjectConnection): Promise<void>
   const projectConfigDir = process.env.AGENT_TEAM_PROJECT_CONFIG_DIR || ".agent-team/projects";
   await fs.rm(path.join(projectConfigDir, `${safeFileSegment(project.projectId)}.yaml`), { force: true });
 
+  const targetRepoConfigPath = path.join(project.localPath, ".agent-team", "config.yaml");
+  try {
+    const config = loadTargetRepoConfig(targetRepoConfigPath);
+    const matchesDeactivatedProject =
+      config.project.id === project.projectId &&
+      config.repo.owner === project.repoOwner &&
+      config.repo.name === project.repoName;
+    if (matchesDeactivatedProject) await fs.rm(targetRepoConfigPath, { force: true });
+  } catch {
+    // If the target-repo config is absent or invalid, the scoped controller cleanup still proceeds.
+  }
+
   const configPath = process.env.AGENT_TEAM_CONFIG || "agent-team.config.yaml";
   try {
     const config = loadTargetRepoConfig(configPath);

--- a/tests/release-activities.test.ts
+++ b/tests/release-activities.test.ts
@@ -16,6 +16,7 @@ import type {
 
 const envKeys = [
   "AGENT_TEAM_CONFIG",
+  "AGENT_TEAM_PROJECT_CONFIG_DIR",
   "AGENT_LOCAL_CHECKS_PASSED",
   "AGENT_GITHUB_ACTIONS_PASSED",
   "AGENT_SECRET_SCAN_PASSED",
@@ -182,6 +183,90 @@ describe("release activities", () => {
       })
     ).toBe(false);
   });
+
+  it("prefers the target repo config file for scoped release work", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-target-config-"));
+    const rootConfigPath = path.join(tempDir, "agent-team.config.yaml");
+    const targetRepoPath = path.join(tempDir, "target-repo");
+    const targetConfigPath = path.join(targetRepoPath, ".agent-team", "config.yaml");
+    await fs.mkdir(path.dirname(targetConfigPath), { recursive: true });
+    await fs.writeFile(rootConfigPath, configYaml(tempDir, 'node -e "process.exit(42)"'), "utf8");
+    await fs.writeFile(targetConfigPath, configYaml(targetRepoPath), "utf8");
+    const store = fakeStore([
+      fakeProjectConnection({
+        projectId: "target-project",
+        repo: "owner/repo",
+        localPath: targetRepoPath
+      })
+    ]);
+    const { performAutonomousRelease } = await loadActivities(store);
+
+    process.env.AGENT_TEAM_CONFIG = rootConfigPath;
+    process.env.AGENT_LOCAL_CHECKS_PASSED = "true";
+    process.env.AGENT_GITHUB_ACTIONS_PASSED = "true";
+    process.env.AGENT_SECRET_SCAN_PASSED = "true";
+    process.env.AGENT_ROLLBACK_PLAN_PRESENT = "true";
+    process.env.AGENT_REQUIRE_RUNTIME_HEALTH = "false";
+    process.env.AGENT_COMMAND_TIMEOUT_MS = "10000";
+
+    try {
+      const artifact = await performAutonomousRelease(
+        workItem({ id: "WI-TARGET", projectId: "target-project", repo: "owner/repo" }),
+        [verificationArtifact()]
+      );
+
+      expect(artifact.status).toBe("passed");
+      await expect(fs.readFile(path.join(targetRepoPath, "release.marker"), "utf8")).resolves.toMatch(
+        /^agent-wi-target-/
+      );
+      await expect(fs.access(path.join(tempDir, "release.marker"))).rejects.toThrow();
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the project config file when the target repo file is absent", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-project-config-"));
+    const rootConfigPath = path.join(tempDir, "agent-team.config.yaml");
+    const targetRepoPath = path.join(tempDir, "target-repo");
+    const projectConfigDir = path.join(tempDir, "project-configs");
+    await fs.mkdir(targetRepoPath, { recursive: true });
+    await fs.mkdir(projectConfigDir, { recursive: true });
+    await fs.writeFile(rootConfigPath, configYaml(tempDir, 'node -e "process.exit(42)"'), "utf8");
+    await fs.writeFile(path.join(projectConfigDir, "target-project.yaml"), configYaml(targetRepoPath), "utf8");
+    const store = fakeStore([
+      fakeProjectConnection({
+        projectId: "target-project",
+        repo: "owner/repo",
+        localPath: targetRepoPath
+      })
+    ]);
+    const { performAutonomousRelease } = await loadActivities(store);
+
+    process.env.AGENT_TEAM_CONFIG = rootConfigPath;
+    process.env.AGENT_TEAM_PROJECT_CONFIG_DIR = projectConfigDir;
+    process.env.AGENT_LOCAL_CHECKS_PASSED = "true";
+    process.env.AGENT_GITHUB_ACTIONS_PASSED = "true";
+    process.env.AGENT_SECRET_SCAN_PASSED = "true";
+    process.env.AGENT_ROLLBACK_PLAN_PRESENT = "true";
+    process.env.AGENT_REQUIRE_RUNTIME_HEALTH = "false";
+    process.env.AGENT_COMMAND_TIMEOUT_MS = "10000";
+
+    try {
+      const artifact = await performAutonomousRelease(
+        workItem({ id: "WI-PROJECT", projectId: "target-project", repo: "owner/repo" }),
+        [verificationArtifact()]
+      );
+
+      expect(artifact.status).toBe("passed");
+      await expect(fs.readFile(path.join(targetRepoPath, "release.marker"), "utf8")).resolves.toMatch(
+        /^agent-wi-project-/
+      );
+      await expect(fs.access(path.join(tempDir, "release.marker"))).rejects.toThrow();
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 async function loadActivities(store: ReturnType<typeof fakeStore>) {
@@ -195,7 +280,7 @@ type FakeStore = ControllerStore & {
   updatedStates: Array<{ id: string; state: string }>;
 };
 
-function fakeStore(): FakeStore {
+function fakeStore(connections: ProjectConnection[] = []): FakeStore {
   const updatedStates: Array<{ id: string; state: string }> = [];
   return {
     updatedStates,
@@ -236,7 +321,7 @@ function fakeStore(): FakeStore {
       };
     },
     async listProjectConnections() {
-      return [];
+      return connections;
     },
     async addArtifact() {},
     async getArtifact() {
@@ -472,7 +557,7 @@ function mcpServerDefaults() {
   };
 }
 
-function workItem(): WorkItem {
+function workItem(overrides: Partial<WorkItem> = {}): WorkItem {
   return {
     id: "WI-RELEASE",
     projectId: "owner-repo",
@@ -489,7 +574,8 @@ function workItem(): WorkItem {
     backendNeeded: true,
     rndNeeded: false,
     createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString()
+    updatedAt: new Date().toISOString(),
+    ...overrides
   };
 }
 


### PR DESCRIPTION
## Summary

Implements queued issue #59 and adds follow-up hardening from local review.

Closes #59

## Scope

- Write generated target repo config to `<localPath>/.agent-team/config.yaml` when a project is connected or activated.
- Prefer the target repo config file in worker release config resolution.
- Preserve the existing project config fallback path.
- Remove the generated target repo config on deactivation when it still matches the deactivated project.
- Add regression coverage for target-file precedence and project-file fallback.

## Validation

- `npm test -- tests/release-activities.test.ts`
- `npm test -- tests/config-schema.test.ts`
- `npm test -- tests/store.test.ts`
- `npm run check`
- `npm run logs:check`
- `npm run diff:budget`
- `docker compose config --no-interpolate --quiet`
- `git diff --check`
- `coderabbit review --agent --base origin/main --type committed -c AGENTS.md -c .coderabbit.yaml` returned 0 issues

## Automation

- Source cloud run: https://github.com/onfire7777/five-agent-dev-team/actions/runs/25259156097
- Follow-up to #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration cleanup during project deactivation with enhanced error resilience when handling missing or invalid configuration files.
  * Updated configuration management to use project-scoped configurations instead of global settings.

* **Tests**
  * Added test coverage for configuration selection precedence logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->