### PR TITLE
Finalize queue issues after Captain merges

### DIFF
--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -680,7 +680,20 @@ jobs:
           gh pr view "$PR_NUMBER" --json number,title,isDraft,mergeStateStatus,reviewDecision,labels,headRefOid,url
           gh pr checks "$PR_NUMBER" --required --watch
           head_sha="$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')"
+          target_issues="$(gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[].number' || true)"
           gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$head_sha"
+
+          for issue_number in $target_issues; do
+            gh issue edit "$issue_number" --add-label agent:done || true
+            gh issue edit "$issue_number" --remove-label agent:ready-for-review || true
+            gh issue edit "$issue_number" --remove-label agent:running || true
+            gh issue edit "$issue_number" --remove-label agent:claimed || true
+            gh issue edit "$issue_number" --remove-label agent:queued || true
+            gh issue close "$issue_number" \
+              --reason completed \
+              --comment "Completed by PR #$PR_NUMBER after Captain merge verification." || true
+          done
+
           gh workflow run codex-cloud-research.yml --ref main
 
       - name: Cloud janitor pass


### PR DESCRIPTION
## Summary

Hardens the cloud Captain merge path so linked queue issues are finalized explicitly after a verified PR merge.

## Why

PR #63 merged successfully, but its linked queue issue #62 remained open until manual cleanup. This patch makes the automation self-heal that bookkeeping gap instead of relying only on GitHub's auto-close behavior.

## Behavior

After Captain verifies and merges a cloud PR, it now:

- reads `closingIssuesReferences` from the PR
- adds `agent:done` to each linked queue issue
- removes transient queue labels such as `agent:ready-for-review`, `agent:running`, `agent:claimed`, and `agent:queued`
- closes the issue as completed with an audit comment
- continues triggering the next Research cycle

## Validation

- `npm run check`
- `npm run logs:check`
- `docker compose config --no-interpolate --quiet`
- `git diff --check`
- `coderabbit review --agent --base origin/main --type uncommitted -c AGENTS.md -c .coderabbit.yaml` — 0 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow automation to automatically close referenced issues when pull requests are merged, with proper status labeling applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->