### PR TITLE
Run Codex cloud research hourly

### DIFF
--- a/.github/workflows/codex-cloud-research.yml
+++ b/.github/workflows/codex-cloud-research.yml
@@ -2,7 +2,7 @@ name: Codex Cloud Research
 
 on:
   schedule:
-    - cron: "7 */6 * * *"
+    - cron: "2 * * * *"
   workflow_dispatch:
     inputs:
       force:


### PR DESCRIPTION
## Summary
- move Codex Cloud Research from every 6 hours to hourly at minute 2
- keep the full cloud loop ordered as Research :02, build lanes :05/:15/:25/:35/:45, Captain :55, Meta Health :57, Janitor :59
- keep Research ahead of the build lane schedule so it can seed queue work inside each hourly loop

## Validation
- git diff --check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- coderabbit review --agent --base origin/main --type uncommitted -c AGENTS.md -c .coderabbit.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow scheduling to improve execution frequency of background processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->