### PR TITLE
Codex Cloud Backend/Core: [Codex Queue] Enforce project-scoped artifact reads

### DIFF
--- a/apps/controller/src/index.ts
+++ b/apps/controller/src/index.ts
@@ -267,7 +267,8 @@ app.get("/api/work-items/:id", async (req, res, next) => {
 
 app.get("/api/artifacts/:id", async (req, res, next) => {
   try {
-    const artifact = await store.getArtifact(req.params.id);
+    const scope = await requireStrictProjectScope(req.query);
+    const artifact = await store.getArtifact(scope, req.params.id);
     if (!artifact) throw new HttpError(`Artifact ${req.params.id} was not found.`, 404);
     res.json(artifact);
   } catch (error) {

--- a/apps/controller/src/store.ts
+++ b/apps/controller/src/store.ts
@@ -234,7 +234,7 @@ export interface ControllerStore {
   createWorkItem(input: WorkItemCreateInput): Promise<WorkItem>;
   updateWorkItemState(id: string, state: WorkItemState): Promise<void>;
   addArtifact(artifact: StageArtifact): Promise<void>;
-  getArtifact(id: string): Promise<StageArtifact | null>;
+  getArtifact(scope: StrictProjectScope, id: string): Promise<StageArtifact | null>;
   addEvent(
     event: Omit<AgentEvent, "sequence" | "createdAt"> & Partial<Pick<AgentEvent, "sequence" | "createdAt">>
   ): Promise<AgentEvent>;
@@ -347,8 +347,14 @@ export class MemoryStore implements ControllerStore {
     await this.addMemories(memoryFromArtifact(parsed));
   }
 
-  async getArtifact(id: string): Promise<StageArtifact | null> {
-    return this.artifacts.find((artifact) => artifact.artifactId === id) || null;
+  async getArtifact(scope: StrictProjectScope, id: string): Promise<StageArtifact | null> {
+    await this.assertProjectScope(scope);
+    return (
+      this.artifacts.find(
+        (artifact) =>
+          artifact.artifactId === id && artifact.projectId === scope.projectId && artifact.repo === scope.repo
+      ) || null
+    );
   }
 
   async addEvent(
@@ -959,10 +965,15 @@ export class PostgresStore extends MemoryStore {
     await super.addArtifact(parsed);
   }
 
-  override async getArtifact(id: string): Promise<StageArtifact | null> {
+  override async getArtifact(scope: StrictProjectScope, id: string): Promise<StageArtifact | null> {
+    await this.assertProjectScope(scope);
     const result = await this.pool.query(
-      "select payload from stage_artifacts where artifact_key = $1 or payload ->> 'artifactId' = $1 limit 1",
-      [id]
+      `select payload from stage_artifacts
+       where (artifact_key = $1 or payload ->> 'artifactId' = $1)
+         and payload ->> 'projectId' = $2
+         and payload ->> 'repo' = $3
+       limit 1`,
+      [id, scope.projectId, scope.repo]
     );
     return result.rows[0] ? StageArtifactSchema.parse(result.rows[0].payload) : null;
   }

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -392,6 +392,8 @@ describe("controller store workflow claims", () => {
 
   it("retrieves work item artifacts by work item and artifact id", async () => {
     const store = new MemoryStore();
+    const scope = await seedScanScope(store, "repo-a");
+    const otherScope = await seedScanScope(store, "repo-b");
     const workItem = await store.createWorkItem({
       title: "Artifact lookup",
       requestType: "feature",
@@ -402,15 +404,15 @@ describe("controller store workflow claims", () => {
       frontendNeeded: true,
       backendNeeded: false,
       rndNeeded: false,
-      projectId: "project-a",
-      repo: "owner/repo-a"
+      projectId: scope.projectId,
+      repo: scope.repo
     });
     const artifact = StageArtifactSchema.parse({
       artifactId: "artifact-lookup-1",
       artifactKind: "BackendImplSummary",
       workItemId: workItem.id,
-      projectId: "project-a",
-      repo: "owner/repo-a",
+      projectId: scope.projectId,
+      repo: scope.repo,
       stage: "BACKEND_BUILD",
       ownerAgent: "backend-systems-engineering",
       status: "passed",
@@ -420,7 +422,7 @@ describe("controller store workflow claims", () => {
       bodyMd: "## Backend implementation summary\n\nLookup endpoints implemented.",
       bodyJson: {
         workItemId: workItem.id,
-        projectId: "project-a",
+        projectId: scope.projectId,
         apiChanges: ["GET /api/work-items/:id", "GET /api/artifacts/:id"]
       },
       createdAt: new Date().toISOString()
@@ -428,10 +430,11 @@ describe("controller store workflow claims", () => {
 
     await store.addArtifact(artifact);
 
-    await expect(store.getArtifact("artifact-lookup-1")).resolves.toMatchObject({
+    await expect(store.getArtifact(scope, "artifact-lookup-1")).resolves.toMatchObject({
       artifactId: "artifact-lookup-1",
       workItemId: workItem.id
     });
+    await expect(store.getArtifact(otherScope, "artifact-lookup-1")).resolves.toBeNull();
     await expect(store.getWorkItemWithArtifacts(workItem.id)).resolves.toMatchObject({
       workItem: { id: workItem.id },
       artifacts: [{ artifactId: "artifact-lookup-1" }]


### PR DESCRIPTION
## Summary

Codex Cloud Backend/Core implemented queued issue #67.

Closes #67

## Scope

[Codex Queue] Enforce project-scoped artifact reads

## Validation

- npm run check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- git diff --check

## Automation

- Stage: Backend/Core
- Run: https://github.com/onfire7777/five-agent-dev-team/actions/runs/25262788642
- Target: #67


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Artifact retrieval now properly enforces project-level isolation, ensuring artifacts are only accessible within their correct project scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->