### PR TITLE
Enable Codex fast mode for cloud workflows

### DIFF
--- a/.github/workflows/codex-ci-autofix.yml
+++ b/.github/workflows/codex-ci-autofix.yml
@@ -53,7 +53,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: ${{ env.CODEX_ACTION_MODEL }}
           effort: ${{ env.CODEX_ACTION_EFFORT }}
-          codex-args: '--config model_verbosity="medium"'
+          codex-args: '--enable fast_mode --config model_verbosity="medium"'
           sandbox: workspace-write
           safety-strategy: drop-sudo
           allow-users: onfire7777

--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -474,7 +474,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: ${{ env.CODEX_ACTION_MODEL }}
           effort: ${{ env.CODEX_ACTION_EFFORT }}
-          codex-args: '--config model_verbosity="medium"'
+          codex-args: '--enable fast_mode --config model_verbosity="medium"'
           sandbox: workspace-write
           safety-strategy: drop-sudo
           allow-users: onfire7777

--- a/.github/workflows/codex-cloud-research.yml
+++ b/.github/workflows/codex-cloud-research.yml
@@ -120,7 +120,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: ${{ env.CODEX_ACTION_MODEL }}
           effort: ${{ env.CODEX_ACTION_EFFORT }}
-          codex-args: '--config model_verbosity="medium"'
+          codex-args: '--enable fast_mode --config model_verbosity="medium"'
           sandbox: read-only
           safety-strategy: drop-sudo
           allow-users: onfire7777

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -45,7 +45,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: ${{ env.CODEX_ACTION_MODEL }}
           effort: ${{ env.CODEX_ACTION_EFFORT }}
-          codex-args: '--config model_verbosity="medium"'
+          codex-args: '--enable fast_mode --config model_verbosity="medium"'
           sandbox: read-only
           safety-strategy: drop-sudo
           allow-users: onfire7777


### PR DESCRIPTION
## Summary
- pass --enable fast_mode through every Codex Action workflow
- keep the existing GPT-5.5/xhigh repository variable model policy

## Validation
- codex features list shows fast_mode is a stable feature and becomes enabled with --enable fast_mode
- git diff --check

## Notes
- This does not change the conservative workflow fallback model; live model selection remains controlled by repository variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled fast_mode for Codex runs across all Codex-related CI workflows.
  * Workflows now pass updated Codex arguments including fast_mode while retaining existing verbosity settings.
  * No other workflow logic, controls, or artifact behaviors were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->