### PR TITLE
Resolve backend Postgres migration blocker

### DIFF
--- a/apps/controller/migrations/001_init.sql
+++ b/apps/controller/migrations/001_init.sql
@@ -1,0 +1,125 @@
+create table if not exists work_items (
+  id text primary key,
+  payload jsonb not null,
+  state text not null,
+  state_changed_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table work_items add column if not exists state_changed_at timestamptz not null default now();
+
+create table if not exists stage_artifacts (
+  id bigserial primary key,
+  work_item_id text not null,
+  artifact_key text,
+  payload jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+alter table stage_artifacts add column if not exists artifact_key text;
+
+create unique index if not exists stage_artifacts_artifact_key_idx
+  on stage_artifacts (artifact_key)
+  where artifact_key is not null;
+
+create table if not exists agent_events (
+  sequence bigserial primary key,
+  work_item_id text,
+  payload jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists memory_records (
+  id text primary key,
+  payload jsonb not null,
+  key text,
+  scope text not null,
+  work_item_id text,
+  importance integer not null,
+  superseded_by text,
+  updated_at timestamptz not null default now()
+);
+
+alter table memory_records add column if not exists key text;
+alter table memory_records add column if not exists superseded_by text;
+
+create unique index if not exists memory_records_live_key_idx
+  on memory_records (
+    scope,
+    key,
+    coalesce(payload->>'projectId', ''),
+    coalesce(payload->>'repo', ''),
+    coalesce(work_item_id, ''),
+    coalesce(payload->>'agent', '')
+  )
+  where key is not null and superseded_by is null;
+
+create table if not exists workflow_claims (
+  work_item_id text primary key,
+  claimed_at timestamptz not null default now()
+);
+
+create table if not exists project_connections (
+  id text primary key,
+  payload jsonb not null,
+  active boolean not null default false,
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists controller_flags (
+  key text primary key,
+  value jsonb not null
+);
+
+create table if not exists team_bus_messages (
+  id text primary key,
+  project_id text not null,
+  repo text not null,
+  payload jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists loop_runs (
+  id text primary key,
+  project_id text not null,
+  repo text not null,
+  payload jsonb not null,
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists project_directions (
+  project_id text not null,
+  repo text not null,
+  payload jsonb not null,
+  updated_at timestamptz not null default now(),
+  primary key (project_id, repo)
+);
+
+create table if not exists opportunities (
+  id text primary key,
+  project_id text not null,
+  repo text not null,
+  payload jsonb not null,
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists opportunity_scan_runs (
+  id text primary key,
+  project_id text not null,
+  repo text not null,
+  payload jsonb not null,
+  started_at timestamptz not null,
+  completed_at timestamptz,
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists opportunity_scan_runs_project_repo_recency_idx
+  on opportunity_scan_runs (project_id, repo, (coalesce(completed_at, started_at)) desc);
+
+create table if not exists proposals (
+  id text primary key,
+  project_id text not null,
+  repo text not null,
+  payload jsonb not null,
+  updated_at timestamptz not null default now()
+);

--- a/apps/controller/src/postgres-migrations.ts
+++ b/apps/controller/src/postgres-migrations.ts
@@ -1,0 +1,84 @@
+import crypto from "node:crypto";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import pg from "pg";
+
+const SCHEMA_NAME = "agent_team";
+const MIGRATIONS_TABLE = `${SCHEMA_NAME}.schema_migrations`;
+
+type MigrationFile = {
+  checksum: string;
+  path: string;
+  sql: string;
+  version: string;
+};
+
+export async function runPostgresMigrations(pool: pg.Pool): Promise<void> {
+  await pool.query(`create schema if not exists ${SCHEMA_NAME}`);
+  await pool.query(`
+    create table if not exists ${MIGRATIONS_TABLE} (
+      version text primary key,
+      checksum text not null,
+      applied_at timestamptz not null default now()
+    )
+  `);
+
+  for (const migration of await loadMigrationFiles()) {
+    const existing = await pool.query<{ checksum: string }>(
+      `select checksum from ${MIGRATIONS_TABLE} where version = $1`,
+      [migration.version]
+    );
+    if (existing.rows[0]) {
+      if (existing.rows[0].checksum !== migration.checksum) {
+        throw new Error(`Migration ${migration.version} checksum changed after it was applied.`);
+      }
+      continue;
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query("begin");
+      await client.query(`set local search_path to ${SCHEMA_NAME}, public`);
+      await client.query(migration.sql);
+      await client.query(`insert into ${MIGRATIONS_TABLE} (version, checksum) values ($1, $2)`, [
+        migration.version,
+        migration.checksum
+      ]);
+      await client.query("commit");
+    } catch (error) {
+      try {
+        await client.query("rollback");
+      } catch (rollbackError) {
+        console.warn("Postgres migration rollback failed.", rollbackError);
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+}
+
+async function loadMigrationFiles(): Promise<MigrationFile[]> {
+  const migrationsDir = path.resolve(process.cwd(), "apps/controller/migrations");
+  const entries = (await readdir(migrationsDir, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".sql"))
+    .map((entry) => entry.name)
+    .sort();
+
+  if (!entries.length) {
+    throw new Error(`No controller migrations found in ${migrationsDir}.`);
+  }
+
+  return Promise.all(
+    entries.map(async (name) => {
+      const migrationPath = path.join(migrationsDir, name);
+      const sql = await readFile(migrationPath, "utf8");
+      return {
+        checksum: crypto.createHash("sha256").update(sql).digest("hex"),
+        path: migrationPath,
+        sql,
+        version: path.basename(name, ".sql")
+      };
+    })
+  );
+}

--- a/apps/controller/src/store.ts
+++ b/apps/controller/src/store.ts
@@ -1,5 +1,6 @@
 import pg from "pg";
 import crypto from "node:crypto";
+import { runPostgresMigrations } from "./postgres-migrations.js";
 import {
   canTransition,
   AgentEventSchema,
@@ -751,7 +752,7 @@ export class PostgresStore extends MemoryStore {
 
   constructor(connectionString: string) {
     super();
-    this.pool = new pg.Pool({ connectionString });
+    this.pool = new pg.Pool({ connectionString, options: "-c search_path=agent_team,public" });
   }
 
   async close(): Promise<void> {
@@ -759,113 +760,7 @@ export class PostgresStore extends MemoryStore {
   }
 
   override async init(): Promise<void> {
-    await this.pool.query(`
-      create table if not exists work_items (
-        id text primary key,
-        payload jsonb not null,
-        state text not null,
-        state_changed_at timestamptz not null default now(),
-        updated_at timestamptz not null default now()
-      );
-      alter table work_items add column if not exists state_changed_at timestamptz not null default now();
-      create table if not exists stage_artifacts (
-        id bigserial primary key,
-        work_item_id text not null,
-        artifact_key text,
-        payload jsonb not null,
-        created_at timestamptz not null default now()
-      );
-      alter table stage_artifacts add column if not exists artifact_key text;
-      create unique index if not exists stage_artifacts_artifact_key_idx on stage_artifacts (artifact_key) where artifact_key is not null;
-      create table if not exists agent_events (
-        sequence bigserial primary key,
-        work_item_id text,
-        payload jsonb not null,
-        created_at timestamptz not null default now()
-      );
-      create table if not exists memory_records (
-        id text primary key,
-        payload jsonb not null,
-        key text,
-        scope text not null,
-        work_item_id text,
-        importance integer not null,
-        superseded_by text,
-        updated_at timestamptz not null default now()
-      );
-      alter table memory_records add column if not exists key text;
-      alter table memory_records add column if not exists superseded_by text;
-      create unique index if not exists memory_records_live_key_idx
-        on memory_records (
-          scope,
-          key,
-          coalesce(payload->>'projectId', ''),
-          coalesce(payload->>'repo', ''),
-          coalesce(work_item_id, ''),
-          coalesce(payload->>'agent', '')
-        )
-        where key is not null and superseded_by is null;
-      create table if not exists workflow_claims (
-        work_item_id text primary key,
-        claimed_at timestamptz not null default now()
-      );
-      create table if not exists project_connections (
-        id text primary key,
-        payload jsonb not null,
-        active boolean not null default false,
-        updated_at timestamptz not null default now()
-      );
-      create table if not exists controller_flags (
-        key text primary key,
-        value jsonb not null
-      );
-      create table if not exists team_bus_messages (
-        id text primary key,
-        project_id text not null,
-        repo text not null,
-        payload jsonb not null,
-        created_at timestamptz not null default now()
-      );
-      create table if not exists loop_runs (
-        id text primary key,
-        project_id text not null,
-        repo text not null,
-        payload jsonb not null,
-        updated_at timestamptz not null default now()
-      );
-      create table if not exists project_directions (
-        project_id text not null,
-        repo text not null,
-        payload jsonb not null,
-        updated_at timestamptz not null default now(),
-        primary key (project_id, repo)
-      );
-      create table if not exists opportunities (
-        id text primary key,
-        project_id text not null,
-        repo text not null,
-        payload jsonb not null,
-        updated_at timestamptz not null default now()
-      );
-      create table if not exists opportunity_scan_runs (
-        id text primary key,
-        project_id text not null,
-        repo text not null,
-        payload jsonb not null,
-        started_at timestamptz not null,
-        completed_at timestamptz,
-        updated_at timestamptz not null default now()
-      );
-      create index if not exists opportunity_scan_runs_project_repo_recency_idx
-        on opportunity_scan_runs (project_id, repo, (coalesce(completed_at, started_at)) desc);
-      create table if not exists proposals (
-        id text primary key,
-        project_id text not null,
-        repo text not null,
-        payload jsonb not null,
-        updated_at timestamptz not null default now()
-      );
-    `);
+    await runPostgresMigrations(this.pool);
     await this.seedProjectConnectionsFromConfig();
   }
 


### PR DESCRIPTION
## Summary
- add a lightweight Postgres migration runner with checksum tracking in agent_team.schema_migrations
- move controller table/index creation into apps/controller/migrations/001_init.sql
- set Postgres connections to search_path=agent_team,public and run migrations during PostgresStore.init

## Fixes
Closes #69.

## Validation
- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- tests/store.test.ts
- npm run logs:check
- npm run check
- docker compose config --no-interpolate --quiet
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced database migration system for schema management with version tracking and integrity verification.
  * Restructured database initialization to use transaction-based migrations with automatic rollback capabilities on errors.
  * Improved database setup reliability and maintainability through standardized migration framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->