### PR TITLE
Unblock cloud automation lanes from dependency PRs

### DIFF
--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -94,6 +94,18 @@ jobs:
               state: "open",
               per_page: 100
             });
+            const isDependencyPr = (pr) => {
+              const author = pr.user?.login || "";
+              const headRef = pr.head?.ref || "";
+              const labels = (pr.labels || []).map((label) => label.name || label);
+              return (
+                author.toLowerCase().includes("dependabot") ||
+                headRef.startsWith("dependabot/") ||
+                labels.includes("dependencies")
+              );
+            };
+            const dependencyPrs = openPrs.filter(isDependencyPr);
+            const blockingOpenPrs = openPrs.filter((pr) => !isDependencyPr(pr));
             const laneOrder = ["backend", "frontend", "quality", "security", "docs"];
             const issueField = (issue, name) =>
               (issue.body || "").match(new RegExp(`^${name}:\\s*(.+)$`, "im"))?.[1]?.toLowerCase() || "";
@@ -284,9 +296,12 @@ jobs:
             }
 
             if (["backend", "frontend", "quality", "security", "docs"].includes(stage)) {
-              if (openPrs.length && !force) {
+              if (blockingOpenPrs.length && !force) {
                 core.setOutput("should_run", "false");
-                core.setOutput("reason", `skipped: ${openPrs.length} open PR(s); Captain must integrate first`);
+                core.setOutput(
+                  "reason",
+                  `skipped: ${blockingOpenPrs.length} non-dependency open PR(s); dependencyPrs=${dependencyPrs.length}`
+                );
                 return;
               }
               const target = openIssues

--- a/.github/workflows/codex-cloud-meta-health.yml
+++ b/.github/workflows/codex-cloud-meta-health.yml
@@ -183,6 +183,18 @@ jobs:
               state: "open",
               per_page: 100
             });
+            const isDependencyPr = (pr) => {
+              const author = pr.user?.login || "";
+              const headRef = pr.head?.ref || "";
+              const labels = (pr.labels || []).map((label) => label.name || label);
+              return (
+                author.toLowerCase().includes("dependabot") ||
+                headRef.startsWith("dependabot/") ||
+                labels.includes("dependencies")
+              );
+            };
+            const dependencyPrs = openPrs.filter(isDependencyPr);
+            const blockingOpenPrs = openPrs.filter((pr) => !isDependencyPr(pr));
 
             const openIssuesRaw = await github.paginate(github.rest.issues.listForRepo, {
               owner,
@@ -244,7 +256,7 @@ jobs:
               .filter((item) => laneOrder.includes(item.lane))
               .sort((a, b) => new Date(a.issue.created_at) - new Date(b.issue.created_at));
 
-            if (!openPrs.length && !queueIssues.length && retryableBlockedIssues.length) {
+            if (!blockingOpenPrs.length && !queueIssues.length && retryableBlockedIssues.length) {
               const { issue, lane } = retryableBlockedIssues[0];
               const labels = labelNamesFor(issue);
               await github.rest.issues.addLabels({
@@ -327,6 +339,8 @@ jobs:
                 buildWorkflowCanWritePullRequests === null ? "unavailable" : String(buildWorkflowCanWritePullRequests)
               }`,
               `Open PRs: ${openPrs.length}`,
+              `Dependency PRs (non-blocking): ${dependencyPrs.length}`,
+              `Blocking PRs: ${blockingOpenPrs.length}`,
               `Open queued/running agent issues: ${queueIssues.length}`,
               `Retryable blocked lane-stop issues: ${retryableBlockedIssues.length}`,
               `Open Dependabot alerts: ${dependabotOpen === null ? "unavailable" : dependabotOpen}`,

--- a/.github/workflows/codex-cloud-research.yml
+++ b/.github/workflows/codex-cloud-research.yml
@@ -55,6 +55,18 @@ jobs:
               state: "open",
               per_page: 100
             });
+            const isDependencyPr = (pr) => {
+              const author = pr.user?.login || "";
+              const headRef = pr.head?.ref || "";
+              const labels = (pr.labels || []).map((label) => label.name || label);
+              return (
+                author.toLowerCase().includes("dependabot") ||
+                headRef.startsWith("dependabot/") ||
+                labels.includes("dependencies")
+              );
+            };
+            const dependencyPrs = openPrs.filter(isDependencyPr);
+            const blockingOpenPrs = openPrs.filter((pr) => !isDependencyPr(pr));
             const openIssuesRaw = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
@@ -69,10 +81,10 @@ jobs:
                 )
               );
 
-            if (!force && (openPrs.length || activeQueueIssues.length)) {
+            if (!force && (blockingOpenPrs.length || activeQueueIssues.length)) {
               return JSON.stringify({
                 run: false,
-                reason: `skipped: openPrs=${openPrs.length}, activeQueueIssues=${activeQueueIssues.length}`
+                reason: `skipped: blockingOpenPrs=${blockingOpenPrs.length}, dependencyPrs=${dependencyPrs.length}, activeQueueIssues=${activeQueueIssues.length}`
               });
             }
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   MemoryStore,
   PostgresStore,
@@ -11,6 +11,14 @@ import {
   type MemoryRecord,
   type StageArtifact
 } from "../packages/shared/src";
+
+beforeEach(() => {
+  vi.stubEnv("AGENT_TEAM_CONFIG", "__missing_agent_team_config_for_store_tests__.yaml");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 async function seedScanScope(store: ControllerStore, repoName: string): Promise<StrictProjectScope> {
   await store.upsertProjectConnection({


### PR DESCRIPTION
## Summary
- treats Dependabot/dependency PRs as non-blocking for Codex Cloud Research and build lanes
- keeps non-dependency PRs serialized through Captain
- updates Meta Health reporting to distinguish total PRs, dependency PRs, and blocking PRs
- isolates store unit tests from ignored machine-local agent-team config

## Validation
- npm run check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- git diff --check

## Result
With the current open PR set, dependency PRs = 5 and blocking PRs = 0, so cloud Research/build lanes can run instead of no-oping solely because Dependabot PRs exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * CI/CD workflows now classify pull requests as dependency-related or blocking, affecting merge gate behavior.
  * Test suite improvements with consistent environment configuration during setup and teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->