### PR TITLE
Allow trusted bot Codex loop runs

### DIFF
--- a/.github/workflows/codex-ci-autofix.yml
+++ b/.github/workflows/codex-ci-autofix.yml
@@ -57,6 +57,7 @@ jobs:
           sandbox: workspace-write
           safety-strategy: drop-sudo
           allow-users: onfire7777
+          allow-bots: true
           output-file: codex-output.md
           prompt: |
             Target: ${{ inputs.target }}

--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -493,6 +493,7 @@ jobs:
           sandbox: workspace-write
           safety-strategy: drop-sudo
           allow-users: onfire7777
+          allow-bots: true
           output-file: codex-output.md
           prompt: |
             You are the Codex Cloud ${{ steps.gate.outputs.stage_display }} specialist for onfire7777/five-agent-dev-team.

--- a/.github/workflows/codex-cloud-research.yml
+++ b/.github/workflows/codex-cloud-research.yml
@@ -140,6 +140,7 @@ jobs:
           sandbox: read-only
           safety-strategy: drop-sudo
           allow-users: onfire7777
+          allow-bots: true
           output-file: codex-output.md
           prompt: |
             You are Stage 0 R&D for onfire7777/five-agent-dev-team.

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -49,6 +49,7 @@ jobs:
           sandbox: read-only
           safety-strategy: drop-sudo
           allow-users: onfire7777
+          allow-bots: true
           output-file: codex-output.md
           prompt: |
             This is PR #${{ github.event.pull_request.number }} for ${{ github.repository }}.


### PR DESCRIPTION
## Summary

- Allow trusted github-actions[bot] loop handoffs to run openai/codex-action.
- Applies to cloud research, cloud build, PR review, and CI autofix Codex action steps.

## Why

The post-Captain research handoff was dispatched by github-actions[bot]; the gate passed, but openai/codex-action rejected the bot because llow-bots was not enabled.

## Validation

- git diff --check
- npm run logs:check
- docker compose config --no-interpolate --quiet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated GitHub Actions workflow configurations to enable bot account participation in Codex CI/CD pipelines across four automated processes: code autofix, cloud build, cloud research, and pull request review. Bot accounts are now authorized to participate in these automated workflows as part of the continuous integration and code review infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->