### PR TITLE
Route agent runtime work to backend lane

### DIFF
--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -134,7 +134,8 @@ jobs:
                 expectedFiles.includes("apps/controller/") ||
                 expectedFiles.includes("apps/worker/") ||
                 expectedFiles.includes("packages/shared/") ||
-                expectedFiles.includes("packages/github/")
+                expectedFiles.includes("packages/github/") ||
+                expectedFiles.includes("packages/agents/src/")
               ) {
                 return "backend";
               }
@@ -224,7 +225,7 @@ jobs:
                 display: "Backend/Core",
                 lane: "backend",
                 label: "codex-stage:backend-core",
-                files: "apps/controller/**, apps/worker/**, packages/shared/**, packages/github/**, backend/schema/store/controller tests",
+                files: "apps/controller/**, apps/worker/**, packages/shared/**, packages/github/**, packages/agents/src/**, backend/schema/store/controller/agent/plugin/release tests",
                 verify: "npm run check && npm run logs:check && docker compose config --no-interpolate --quiet"
               },
               frontend: {

--- a/.github/workflows/codex-cloud-meta-health.yml
+++ b/.github/workflows/codex-cloud-meta-health.yml
@@ -230,7 +230,8 @@ jobs:
                 expectedFiles.includes("apps/controller/") ||
                 expectedFiles.includes("apps/worker/") ||
                 expectedFiles.includes("packages/shared/") ||
-                expectedFiles.includes("packages/github/")
+                expectedFiles.includes("packages/github/") ||
+                expectedFiles.includes("packages/agents/src/")
               ) {
                 return "backend";
               }

--- a/.github/workflows/codex-cloud-research.yml
+++ b/.github/workflows/codex-cloud-research.yml
@@ -151,7 +151,7 @@ jobs:
             Only propose work that maps to the implementation spec and real product behavior, and can run in codex-cloud, codex-action, or agentic-workflow.
             When no PR or active queue issue exists, prefer producing the next bounded implementation slice from docs/implementation-spec.md.
             Choose the lane from the expected file ownership, not from the broad topic:
-            - backend: apps/controller/**, apps/worker/**, packages/shared/**, packages/github/**, backend/schema/store/controller tests.
+            - backend: apps/controller/**, apps/worker/**, packages/shared/**, packages/github/**, packages/agents/src/**, backend/schema/store/controller/agent/plugin/release tests.
             - frontend: apps/dashboard/** and dashboard e2e coverage.
             - quality: tests/**, Playwright config, test utilities, reproductions, and acceptance evidence only.
             - security: .github/**, CI workflows, Dockerfile, docker-compose.yml, .env.example, package*.json, audit/security/check scripts, release/**, auth/security/permission work.


### PR DESCRIPTION
## Summary

- Add packages/agents/src/** to Backend/Core cloud lane ownership.
- Teach build/meta-health lane inference that agent runtime source belongs to backend.
- Align the research prompt so future plugin-host and agent-runtime issues are not misrouted into a blocked state.

## Why

Issue #86 was valid product work, but the backend lane refused it because packages/agents/src/** had no mutating lane owner in the cloud build contract.

## Validation

- git diff --check
- npm run logs:check
- docker compose config --no-interpolate --quiet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configurations to improve internal issue classification and backend release test path management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->