### PR TITLE
Codex Cloud Backend/Core: [Codex Queue] Finish allowlisted plugin contribution plumbing

### DIFF
--- a/apps/worker/src/activities.ts
+++ b/apps/worker/src/activities.ts
@@ -690,16 +690,39 @@ export async function performAutonomousRelease(
   workItem: WorkItem,
   previousArtifacts: StageArtifact[]
 ): Promise<StageArtifact> {
-  const config = await loadReleaseConfig(workItem);
-  const scopedWorkItem = scopeWorkItemToProject(workItem, config);
-  await ensureNotStopped(scopedWorkItem.id, config);
+  const baseConfig = await loadReleaseConfig(workItem);
+  const scopedWorkItem = scopeWorkItemToProject(workItem, baseConfig);
+  await ensureNotStopped(scopedWorkItem.id, baseConfig);
+  const loadedPlugins = await initializePlugins(baseConfig);
+  const config = mergePluginContributions(baseConfig, loadedPlugins);
+  try {
+    return await performAutonomousReleaseWithConfig(scopedWorkItem, previousArtifacts, config);
+  } finally {
+    await disposePlugins(loadedPlugins, config.repo.localPath || process.cwd()).catch(() => undefined);
+  }
+}
+
+async function performAutonomousReleaseWithConfig(
+  scopedWorkItem: WorkItem,
+  previousArtifacts: StageArtifact[],
+  config: TargetRepoConfig
+): Promise<StageArtifact> {
   const releaseTag = releaseTagForWorkItem(scopedWorkItem);
   const rollback = rollbackPlanForRelease(scopedWorkItem, config, releaseTag);
-  const { signal, syncReasons } = await collectReleaseSignal(scopedWorkItem, config, previousArtifacts, releaseTag);
-  const preReleaseDecision = evaluateReleasePolicy(config, {
-    ...signal,
-    releaseProofPresent: signal.releaseProofPresent || Boolean(config.commands.release.trim())
-  });
+  const { signal, syncReasons, pluginReleaseGateResults } = await collectReleaseSignal(
+    scopedWorkItem,
+    config,
+    previousArtifacts,
+    releaseTag
+  );
+  const preReleaseDecision = withPluginReleaseGateDecision(
+    evaluateReleasePolicy(config, {
+      ...signal,
+      releaseProofPresent: signal.releaseProofPresent || Boolean(config.commands.release.trim())
+    }),
+    config,
+    pluginReleaseGateResults
+  );
   const releaseCommand = preReleaseDecision.allowed
     ? await runReleaseCommand(config, scopedWorkItem, releaseTag)
     : null;
@@ -717,10 +740,14 @@ export async function performAutonomousRelease(
     signal.releaseProofPresent ||
     Boolean(releaseCommand?.ok) ||
     (await hasReleaseProof(scopedWorkItem, config, releaseTag));
-  const decision = evaluateReleasePolicy(config, {
-    ...signal,
-    releaseProofPresent
-  });
+  const decision = withPluginReleaseGateDecision(
+    evaluateReleasePolicy(config, {
+      ...signal,
+      releaseProofPresent
+    }),
+    config,
+    pluginReleaseGateResults
+  );
   const postReleaseHealthPassed = !postReleaseHealth || !postReleaseHealth.required || postReleaseHealth.ok;
   const releaseAllowed = decision.allowed && (!releaseCommand || releaseCommand.ok) && postReleaseHealthPassed;
   const releasePacket = ReleasePacketSchema.parse({
@@ -736,6 +763,7 @@ export async function performAutonomousRelease(
         passed: decision.allowed,
         evidence: decision.allowed ? "Policy allowed release." : decision.requiredFixes.join("; ")
       },
+      ...pluginReleaseGatePacketEntries(config, pluginReleaseGateResults),
       {
         name: "release-command",
         passed: !releaseCommand || releaseCommand.ok,
@@ -798,6 +826,7 @@ export async function performAutonomousRelease(
       "secret scan",
       `release-proof:${releaseProofPresent ? "present" : "missing"}`,
       "release verification",
+      ...pluginReleaseGateTestNames(config, pluginReleaseGateResults),
       ...(releaseCommand ? [`release:${releaseCommand.ok ? "passed" : "failed"}`] : []),
       ...(postReleaseHealth ? [`post-release-health:${postReleaseHealth.ok ? "passed" : "failed"}`] : []),
       ...(rollbackCommand ? [`rollback:${rollbackCommand.ok ? "passed" : "failed"}`] : [])
@@ -960,7 +989,7 @@ async function collectReleaseSignal(
   config: TargetRepoConfig,
   previousArtifacts: StageArtifact[],
   releaseTag?: string
-): Promise<{ signal: VerificationSignal; syncReasons: string[] }> {
+): Promise<{ signal: VerificationSignal; syncReasons: string[]; pluginReleaseGateResults: Record<string, boolean> }> {
   const [gitSyncInput, githubActions] = await Promise.all([
     readGitSyncInput(workItem, config),
     readGitHubActionsEvidence(config)
@@ -992,8 +1021,103 @@ async function collectReleaseSignal(
     syncReasons: uniqueStrings([
       ...sync.reasons,
       ...(githubActions.required && !githubActions.ok ? githubActions.risks : [])
-    ])
+    ]),
+    pluginReleaseGateResults: collectPluginReleaseGateResults(config, previousArtifacts)
   };
+}
+
+function collectPluginReleaseGateResults(
+  config: TargetRepoConfig,
+  previousArtifacts: StageArtifact[]
+): Record<string, boolean> {
+  const gateIds = new Set((config.integrations.pluginContributions?.releaseGates || []).map((gate) => gate.id));
+  if (!gateIds.size) return {};
+  const results: Record<string, boolean> = {};
+  for (const artifact of previousArtifacts) {
+    const structured = (artifact.bodyJson as { pluginReleaseGateResults?: unknown }).pluginReleaseGateResults;
+    if (structured && typeof structured === "object" && !Array.isArray(structured)) {
+      for (const [id, passed] of Object.entries(structured)) {
+        if (gateIds.has(id) && typeof passed === "boolean") results[id] = passed;
+      }
+    }
+    for (const id of gateIds) {
+      if (artifact.testsRun.includes(`plugin-release-gate:${id}:passed`)) results[id] = true;
+      if (artifact.testsRun.includes(`plugin-release-gate:${id}:failed`)) results[id] = false;
+    }
+  }
+  return results;
+}
+
+function withPluginReleaseGateDecision(
+  decision: ReturnType<typeof evaluateReleasePolicy>,
+  config: TargetRepoConfig,
+  results: Record<string, boolean>
+): ReturnType<typeof evaluateReleasePolicy> {
+  const gateDecision = evaluatePluginReleaseGates(config, results);
+  const requiredFixes = [...decision.requiredFixes, ...gateDecision.requiredFixes];
+  const allowed = decision.allowed && requiredFixes.length === 0;
+  return {
+    allowed,
+    recommendation: allowed ? "go" : "no_go",
+    reasons: [...decision.reasons, ...gateDecision.reasons],
+    requiredFixes
+  };
+}
+
+function evaluatePluginReleaseGates(
+  config: TargetRepoConfig,
+  results: Record<string, boolean>
+): { reasons: string[]; requiredFixes: string[] } {
+  const reasons: string[] = [];
+  const requiredFixes: string[] = [];
+  for (const gate of config.integrations.pluginContributions?.releaseGates || []) {
+    const result = results[gate.id];
+    if (result === true) {
+      reasons.push(`Plugin release gate ${gate.id} passed.`);
+    } else if (gate.required && result === false) {
+      requiredFixes.push(`Required plugin release gate ${gate.id} failed.`);
+    } else if (gate.required) {
+      requiredFixes.push(`Required plugin release gate ${gate.id} has not been evaluated safely.`);
+    } else {
+      reasons.push(`Optional plugin release gate ${gate.id} is registered but not required.`);
+    }
+  }
+  return { reasons, requiredFixes };
+}
+
+function pluginReleaseGatePacketEntries(
+  config: TargetRepoConfig,
+  results: Record<string, boolean>
+): Array<{ name: string; passed: boolean; evidence: string }> {
+  return (config.integrations.pluginContributions?.releaseGates || []).map((gate) => {
+    const result = results[gate.id];
+    if (result === true) {
+      return { name: `plugin:${gate.id}`, passed: true, evidence: "Plugin release gate passed." };
+    }
+    if (result === false) {
+      return {
+        name: `plugin:${gate.id}`,
+        passed: !gate.required,
+        evidence: gate.required
+          ? "Required plugin release gate failed."
+          : "Optional plugin release gate failed without blocking release."
+      };
+    }
+    return {
+      name: `plugin:${gate.id}`,
+      passed: !gate.required,
+      evidence: gate.required
+        ? "Required plugin release gate has not been evaluated safely."
+        : "Optional plugin release gate was not evaluated."
+    };
+  });
+}
+
+function pluginReleaseGateTestNames(config: TargetRepoConfig, results: Record<string, boolean>): string[] {
+  return (config.integrations.pluginContributions?.releaseGates || []).map((gate) => {
+    const result = results[gate.id];
+    return `plugin-release-gate:${gate.id}:${result === true ? "passed" : result === false ? "failed" : "missing"}`;
+  });
 }
 
 async function readGitSyncInput(workItem: WorkItem, config: TargetRepoConfig) {

--- a/packages/agents/src/plugin-host.ts
+++ b/packages/agents/src/plugin-host.ts
@@ -29,7 +29,6 @@ export async function initializePlugins(config: TargetRepoConfig): Promise<Loade
       if (plugin.repo && plugin.repo !== `${config.repo.owner}/${config.repo.name}`) {
         throw new Error(`Plugin ${plugin.name} is scoped to another repo.`);
       }
-      assertNoUnsupportedContributions(plugin);
       loaded.push({ plugin, contribution: plugin.contributions });
       if (plugin.initCommand) await runLifecycleCommand(plugin.initCommand, config.repo.localPath);
     }
@@ -57,9 +56,7 @@ export async function disposePlugins(plugins: LoadedPlugin[], cwd: string): Prom
 
 export function mergePluginContributions(config: TargetRepoConfig, plugins: LoadedPlugin[]): TargetRepoConfig {
   if (!plugins.length) return config;
-  for (const loaded of plugins) {
-    assertNoUnsupportedContributions(loaded.plugin);
-  }
+  const pluginContributions = mergeContributions(config.integrations.pluginContributions, plugins);
   return {
     ...config,
     integrations: {
@@ -69,20 +66,20 @@ export function mergePluginContributions(config: TargetRepoConfig, plugins: Load
         ...plugins.flatMap((loaded) => loaded.contribution.capabilities)
       ],
       mcpServers: [...config.integrations.mcpServers, ...plugins.flatMap((loaded) => loaded.contribution.mcpServers)],
+      pluginContributions,
       plugins: config.integrations.plugins
     }
   };
 }
 
-function assertNoUnsupportedContributions(plugin: AgentTeamPlugin): void {
-  const unsupported = [
-    plugin.contributions.skills.length ? "skills" : null,
-    plugin.contributions.tools.length ? "tools" : null,
-    plugin.contributions.releaseGates.length ? "releaseGates" : null
-  ].filter((value): value is string => Boolean(value));
-  if (unsupported.length) {
-    throw new Error(`Plugin ${plugin.name} declares unsupported contributions: ${unsupported.join(", ")}.`);
-  }
+function mergeContributions(existing: PluginContribution | undefined, plugins: LoadedPlugin[]): PluginContribution {
+  return {
+    capabilities: [...(existing?.capabilities || []), ...plugins.flatMap((loaded) => loaded.contribution.capabilities)],
+    mcpServers: [...(existing?.mcpServers || []), ...plugins.flatMap((loaded) => loaded.contribution.mcpServers)],
+    skills: [...(existing?.skills || []), ...plugins.flatMap((loaded) => loaded.contribution.skills)],
+    tools: [...(existing?.tools || []), ...plugins.flatMap((loaded) => loaded.contribution.tools)],
+    releaseGates: [...(existing?.releaseGates || []), ...plugins.flatMap((loaded) => loaded.contribution.releaseGates)]
+  };
 }
 
 async function runLifecycleCommand(command: string, cwd: string): Promise<void> {

--- a/packages/agents/src/skills.ts
+++ b/packages/agents/src/skills.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import YAML from "yaml";
-import type { AgentRole, TargetRepoConfig, WorkItem, WorkItemState } from "../../shared/src";
+import type { AgentRole, PluginSkillContribution, TargetRepoConfig, WorkItem, WorkItemState } from "../../shared/src";
 
 export interface SkillActivationInput {
   workItem: WorkItem;
@@ -38,13 +38,18 @@ type SkillFrontmatter = {
 
 const SKILL_TEXT_BUDGET = 16_384;
 const MAX_SKILL_BODY_BYTES = 4_096;
+const ABSOLUTE_PATH_REGEX = /^(?:\/|[A-Za-z]:[\\/])/;
 
 export async function loadTriggeredSkills(input: SkillActivationInput): Promise<SkillLoadResult> {
   const root = path.resolve(process.cwd(), "packages/agents/skills");
   const files = await findSkillFiles(root);
-  const candidates = (await Promise.all(files.map(readSkillFile))).filter(
-    (skill): skill is LoadedSkill & { trigger?: SkillFrontmatter["trigger"] } => Boolean(skill)
-  );
+  const declaredPluginSkills = pluginSkillFiles(input.targetRepoConfig);
+  const candidates = (
+    await Promise.all([
+      ...files.map(readSkillFile),
+      ...declaredPluginSkills.map(({ declaration, filePath }) => readDeclaredPluginSkillFile(declaration, filePath))
+    ])
+  ).filter((skill): skill is LoadedSkill & { trigger?: SkillFrontmatter["trigger"] } => Boolean(skill));
 
   const active = candidates
     .filter((skill) => skill.audience.includes(input.agent))
@@ -64,6 +69,40 @@ export async function loadTriggeredSkills(input: SkillActivationInput): Promise<
     skills.push(stripTrigger(skill));
   }
   return { skills, droppedSkillIds };
+}
+
+function pluginSkillFiles(
+  config?: TargetRepoConfig
+): Array<{ declaration: PluginSkillContribution; filePath: string }> {
+  if (!config?.integrations.pluginContributions?.skills.length) return [];
+  const repoRoot = path.resolve(config.repo.localPath || process.cwd());
+  return config.integrations.pluginContributions.skills.map((declaration) => ({
+    declaration,
+    filePath: resolvePluginSkillPath(repoRoot, declaration.relativePath)
+  }));
+}
+
+function resolvePluginSkillPath(repoRoot: string, relativePath: string): string {
+  if (ABSOLUTE_PATH_REGEX.test(relativePath) || path.isAbsolute(relativePath)) {
+    throw new Error(`Plugin skill path must be relative: ${relativePath}`);
+  }
+  const resolved = path.resolve(repoRoot, relativePath);
+  const relative = path.relative(repoRoot, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Plugin skill path escapes the connected repository: ${relativePath}`);
+  }
+  return resolved;
+}
+
+async function readDeclaredPluginSkillFile(
+  declaration: PluginSkillContribution,
+  filePath: string
+): Promise<(LoadedSkill & { trigger?: SkillFrontmatter["trigger"] }) | null> {
+  const skill = await readSkillFile(filePath);
+  if (skill && skill.id !== declaration.id) {
+    throw new Error(`Plugin skill declaration ${declaration.id} does not match loaded skill ${skill.id}: ${filePath}`);
+  }
+  return skill;
 }
 
 async function findSkillFiles(root: string): Promise<string[]> {

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -894,34 +894,42 @@ export const CapabilityPackSchema = z.object({
 
 export type CapabilityPack = z.infer<typeof CapabilityPackSchema>;
 
+const PluginRelativePathSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (value) => !ABSOLUTE_LOCAL_PATH_REGEX.test(value) && !/(^|[\\/])\.\.([\\/]|$)/.test(value),
+    "Plugin paths must be relative and stay inside the connected repository."
+  );
+
+export const PluginSkillContributionSchema = z.object({
+  id: z.string().min(1),
+  relativePath: PluginRelativePathSchema
+});
+
+export type PluginSkillContribution = z.infer<typeof PluginSkillContributionSchema>;
+
+export const PluginToolContributionSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1)
+});
+
+export type PluginToolContribution = z.infer<typeof PluginToolContributionSchema>;
+
+export const PluginReleaseGateSchema = z.object({
+  id: z.string().min(1),
+  command: z.string().min(1),
+  required: z.boolean().default(true)
+});
+
+export type PluginReleaseGate = z.infer<typeof PluginReleaseGateSchema>;
+
 export const PluginContributionSchema = z.object({
   capabilities: z.array(CapabilityPackSchema).default([]),
   mcpServers: z.array(McpServerConfigSchema).default([]),
-  skills: z
-    .array(
-      z.object({
-        id: z.string().min(1),
-        relativePath: z.string().min(1)
-      })
-    )
-    .default([]),
-  tools: z
-    .array(
-      z.object({
-        name: z.string().min(1),
-        description: z.string().min(1)
-      })
-    )
-    .default([]),
-  releaseGates: z
-    .array(
-      z.object({
-        id: z.string().min(1),
-        command: z.string().min(1),
-        required: z.boolean().default(true)
-      })
-    )
-    .default([])
+  skills: z.array(PluginSkillContributionSchema).default([]),
+  tools: z.array(PluginToolContributionSchema).default([]),
+  releaseGates: z.array(PluginReleaseGateSchema).default([])
 });
 
 export type PluginContribution = z.infer<typeof PluginContributionSchema>;
@@ -1017,6 +1025,7 @@ export const TargetRepoConfigSchema = z.object({
       }),
       mcpServers: z.array(McpServerConfigSchema).default([]),
       capabilityPacks: z.array(CapabilityPackSchema).default([]),
+      pluginContributions: PluginContributionSchema.optional(),
       plugins: z.array(AgentTeamPluginSchema).default([])
     })
     .default({

--- a/tests/agent-runner.test.ts
+++ b/tests/agent-runner.test.ts
@@ -1,4 +1,7 @@
 import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { getAgentDefinition, resolveMcpEnv, runRoleAgent } from "../packages/agents/src";
 import { DEFAULT_RELEASE_COMMAND, TargetRepoConfigSchema, type WorkItem } from "../packages/shared/src";
@@ -323,15 +326,65 @@ describe("agent runner", () => {
     expect(result.artifact.testsRun).toEqual([]);
     expect(result.artifact.releaseReadiness).toBe("unknown");
   });
+
+  it("loads triggered plugin-contributed skills from merged runtime contributions", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-plugin-skill-"));
+    try {
+      const skillPath = path.join(tempDir, "skills", "browser-smoke", "SKILL.md");
+      await fs.mkdir(path.dirname(skillPath), { recursive: true });
+      await fs.writeFile(
+        skillPath,
+        `---
+id: browser-smoke
+name: Browser Smoke
+audience:
+  - backend-systems-engineering
+priority: 80
+trigger:
+  always: true
+---
+Use the plugin-provided browser smoke procedure when the work item requires UI release evidence.
+`,
+        "utf8"
+      );
+
+      const result = await runRoleAgent(getAgentDefinition("backend-systems-engineering"), {
+        workItem: { ...workItem, state: "BACKEND_BUILD" },
+        stage: "BACKEND_BUILD",
+        previousArtifacts: [],
+        targetRepoConfig: liveTargetConfig({
+          repoPath: tempDir,
+          pluginContributions: {
+            capabilities: [],
+            mcpServers: [],
+            skills: [{ id: "browser-smoke", relativePath: "skills/browser-smoke/SKILL.md" }],
+            tools: [{ name: "browser.screenshot", description: "Capture a browser screenshot." }],
+            releaseGates: [{ id: "browser-smoke-gate", command: "npm run browser:smoke", required: true }]
+          }
+        })
+      });
+
+      expect(result.artifact.skillIds).toContain("browser-smoke");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
-function liveTargetConfig(overrides: { mcpServers?: unknown[]; capabilityPacks?: unknown[] } = {}) {
+function liveTargetConfig(
+  overrides: {
+    mcpServers?: unknown[];
+    capabilityPacks?: unknown[];
+    pluginContributions?: unknown;
+    repoPath?: string;
+  } = {}
+) {
   return TargetRepoConfigSchema.parse({
     repo: {
       owner: "owner",
       name: "repo",
       defaultBranch: "main",
-      localPath: process.cwd()
+      localPath: overrides.repoPath || process.cwd()
     },
     commands: {
       install: "npm ci",
@@ -345,7 +398,8 @@ function liveTargetConfig(overrides: { mcpServers?: unknown[]; capabilityPacks?:
     integrations: {
       mcpServers: overrides.mcpServers || [],
       capabilityPacks: overrides.capabilityPacks || [],
-      plugins: []
+      plugins: [],
+      ...(overrides.pluginContributions ? { pluginContributions: overrides.pluginContributions } : {})
     },
     models: {
       primaryCodingModel: "gpt-primary",

--- a/tests/plugin-host.test.ts
+++ b/tests/plugin-host.test.ts
@@ -143,9 +143,9 @@ const contributionPlugin: AgentTeamPlugin = {
         notes: []
       }
     ],
-    skills: [],
-    tools: [],
-    releaseGates: []
+    skills: [{ id: "browser-smoke", relativePath: "skills/browser-smoke/SKILL.md" }],
+    tools: [{ name: "browser.screenshot", description: "Capture a browser screenshot." }],
+    releaseGates: [{ id: "browser-smoke-gate", command: "npm run browser:smoke", required: true }]
   }
 };
 
@@ -173,31 +173,46 @@ describe("plugin host", () => {
     await expect(initializePlugins(config)).rejects.toThrow(/not allowlisted/);
   });
 
-  it("merges allowlisted plugin contributions into runtime integrations", async () => {
-    const config = configWithPlugins([contributionPlugin]);
-    const loaded = await initializePlugins(config);
-    const merged = mergePluginContributions(config, loaded);
-
-    expect(loaded).toHaveLength(1);
-    expect(merged.integrations.capabilityPacks[0].name).toBe("Browser smoke testing");
-    expect(merged.integrations.mcpServers[0].name).toBe("browser-use");
-    expect(merged.integrations.plugins).toHaveLength(1);
+  it("requires enabled plugins to match project and repo scope", async () => {
+    await expect(
+      initializePlugins(configWithPlugins([{ ...contributionPlugin, projectId: "project-b" }]))
+    ).rejects.toThrow(/another project/);
+    await expect(initializePlugins(configWithPlugins([{ ...contributionPlugin, repo: "acme/other" }]))).rejects.toThrow(
+      /another repo/
+    );
   });
 
-  it("rejects unsupported plugin contributions instead of silently dropping them", async () => {
-    const config = configWithPlugins([
-      {
+  it("merges allowlisted P6-A3/A22 plugin contributions into runtime integrations", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "plugin-contributions-"));
+    try {
+      const plugin = {
         ...contributionPlugin,
         contributions: {
           ...contributionPlugin.contributions,
-          skills: [{ id: "browser-smoke", relativePath: "skills/browser-smoke/SKILL.md" }],
-          tools: [{ name: "browser.screenshot", description: "Capture a browser screenshot." }],
-          releaseGates: [{ id: "browser-smoke-gate", command: "npm run browser:smoke", required: true }]
+          releaseGates: [
+            {
+              id: "browser-smoke-gate",
+              command: "node -e \"require('fs').writeFileSync('gate-ran.txt','1')\"",
+              required: true
+            }
+          ]
         }
-      }
-    ]);
+      };
+      const config = configWithPlugins([plugin], tempDir);
+      const loaded = await initializePlugins(config);
+      const merged = mergePluginContributions(config, loaded);
 
-    await expect(initializePlugins(config)).rejects.toThrow(/unsupported contributions: skills, tools, releaseGates/);
+      expect(loaded).toHaveLength(1);
+      expect(merged.integrations.capabilityPacks[0].name).toBe("Browser smoke testing");
+      expect(merged.integrations.mcpServers[0].name).toBe("browser-use");
+      expect(merged.integrations.pluginContributions?.skills).toEqual(plugin.contributions.skills);
+      expect(merged.integrations.pluginContributions?.tools).toEqual(plugin.contributions.tools);
+      expect(merged.integrations.pluginContributions?.releaseGates).toEqual(plugin.contributions.releaseGates);
+      expect(merged.integrations.plugins).toHaveLength(1);
+      expect(existsSync(join(tempDir, "gate-ran.txt"))).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("preserves quoted lifecycle command arguments", () => {

--- a/tests/release-activities.test.ts
+++ b/tests/release-activities.test.ts
@@ -140,6 +140,50 @@ describe("release activities", () => {
     expect(store.updatedStates).toEqual([{ id: "WI-RELEASE", state: "BLOCKED" }]);
   });
 
+  it("fails closed before release when a required plugin release gate lacks safe evaluation", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-plugin-release-gate-"));
+    const configPath = path.join(tempDir, "agent-team.config.yaml");
+    await fs.writeFile(
+      configPath,
+      configYaml(tempDir).replace(
+        "  plugins: []",
+        `  plugins:
+    - name: Browser Gate
+      packageName: "@agent-team/browser-gate"
+      enabled: true
+      allowlisted: true
+      repo: owner/repo
+      contributions:
+        releaseGates:
+          - id: browser-smoke-gate
+            command: "npm run browser:smoke"
+            required: true`
+      ),
+      "utf8"
+    );
+    const store = fakeStore();
+    const { performAutonomousRelease } = await loadActivities(store);
+
+    process.env.AGENT_TEAM_CONFIG = configPath;
+    process.env.AGENT_LOCAL_CHECKS_PASSED = "true";
+    process.env.AGENT_GITHUB_ACTIONS_PASSED = "true";
+    process.env.AGENT_SECRET_SCAN_PASSED = "true";
+    process.env.AGENT_ROLLBACK_PLAN_PRESENT = "true";
+    process.env.AGENT_REQUIRE_RUNTIME_HEALTH = "false";
+    process.env.AGENT_COMMAND_TIMEOUT_MS = "10000";
+
+    try {
+      const artifact = await performAutonomousRelease(workItem(), [verificationArtifact()]);
+
+      expect(artifact.status).toBe("blocked");
+      expect(artifact.summary).toContain("Required plugin release gate browser-smoke-gate");
+      expect(artifact.testsRun).toContain("plugin-release-gate:browser-smoke-gate:missing");
+      await expect(fs.access(path.join(tempDir, "release.marker"))).rejects.toThrow();
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("detects write-capable GitHub integrations by category", async () => {
     const { hasGithubWriteIntegration } = await loadActivities(fakeStore());
     const config = targetRepoConfig(process.cwd());


### PR DESCRIPTION
## Summary

Codex Cloud Backend/Core implemented queued issue #86.

Closes #86

## Scope

[Codex Queue] Finish allowlisted plugin contribution plumbing

## Validation

- npm run check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- git diff --check

## Automation

- Stage: Backend/Core
- Run: https://github.com/onfire7777/five-agent-dev-team/actions/runs/25338897852
- Target: #86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins can now provide release gates to influence release decisions.
  * Skills and tools can be contributed by plugins through configuration.

* **Improvements**
  * Release process now properly manages plugin initialization and cleanup.
  * Path validation added to ensure safety of plugin-contributed skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->