### PR TITLE
Expose built-in agent tools in live runner

### DIFF
--- a/apps/worker/src/activities.ts
+++ b/apps/worker/src/activities.ts
@@ -406,7 +406,19 @@ async function runAgentWithTeamContext(
       proposalStage,
       teamMessages,
       teamDirection: [...buildTeamDirection(input, proposalStage), ...(input.teamDirection || [])],
-      loopContext: [...buildLoopContext(input.previousArtifacts), ...(input.loopContext || [])]
+      loopContext: [...buildLoopContext(input.previousArtifacts), ...(input.loopContext || [])],
+      emitEvent: async (event) => {
+        await store.addEvent({
+          workItemId: scopedWorkItem.id,
+          projectId: scopedWorkItem.projectId,
+          repo: scopedWorkItem.repo,
+          stage: input.stage,
+          ownerAgent: definition.role,
+          level: event.level,
+          type: event.type === "agent.blocked" ? "stage_failed" : event.type,
+          message: event.message
+        });
+      }
     });
     return { artifact: result.artifact, definition, store, workItem: scopedWorkItem };
   } finally {

--- a/packages/agents/src/prompt.ts
+++ b/packages/agents/src/prompt.ts
@@ -80,11 +80,31 @@ export function assembleCanonicalPrompt(input: PromptAssemblyInput): PromptAssem
       JSON.stringify(
         {
           builtIns: [
-            { name: "memory.search", description: "Read project-scoped durable memory records." },
-            { name: "repo.context.read", description: "Read curated project context files inside the connected repo." },
-            { name: "artifact.write", description: "Persist exactly one validated stage artifact." },
-            { name: "event.emit", description: "Emit a project-scoped workflow event." },
-            { name: "skill.load", description: "Request an audience-allowed skill by id." }
+            {
+              name: "memory.search",
+              callName: "memory.search",
+              description: "Read project-scoped durable memory records."
+            },
+            {
+              name: "repo.context.read",
+              callName: "repo_context.read",
+              description: "Read curated project context files inside the connected repo."
+            },
+            {
+              name: "artifact.write",
+              callName: "artifact.write",
+              description: "Persist exactly one validated stage artifact."
+            },
+            {
+              name: "event.emit",
+              callName: "event.emit",
+              description: "Emit a project-scoped workflow event."
+            },
+            {
+              name: "skill.load",
+              callName: "skill.load",
+              description: "Request an audience-allowed skill by id."
+            }
           ],
           activeCapabilityIds: input.capabilityIds
         },

--- a/packages/agents/src/runner.ts
+++ b/packages/agents/src/runner.ts
@@ -1,5 +1,9 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
 import type { AgentDefinition } from "./definitions";
 import type {
+  AgentEvent,
   McpServerConfig,
   MemoryRecord,
   StageArtifact,
@@ -8,7 +12,7 @@ import type {
   WorkItemState
 } from "../../shared/src";
 import { assembleCanonicalPrompt } from "./prompt";
-import { loadTriggeredSkills, type LoadedSkill } from "./skills";
+import { loadSkillById, loadTriggeredSkills, type LoadedSkill } from "./skills";
 import {
   DEFAULT_SCHEDULER_POLICY,
   githubToken,
@@ -25,6 +29,12 @@ export interface TeamBusMessage {
   message: string;
 }
 
+export type AgentToolEventInput = {
+  level: AgentEvent["level"];
+  type: AgentEvent["type"] | "agent.blocked";
+  message: string;
+};
+
 export interface AgentRunContext {
   workItem: WorkItem;
   stage: WorkItemState;
@@ -36,6 +46,7 @@ export interface AgentRunContext {
   teamMessages?: TeamBusMessage[];
   teamDirection?: string[];
   loopContext?: string[];
+  emitEvent?: (event: AgentToolEventInput) => Promise<void>;
 }
 
 export interface AgentRunResult {
@@ -61,6 +72,47 @@ type ConfiguredHostedTool = {
   id: string;
   tool: any;
 };
+
+const BUILT_IN_TOOL_IDS = [
+  "builtin:memory.search",
+  "builtin:repo.context.read",
+  "builtin:artifact.write",
+  "builtin:event.emit",
+  "builtin:skill.load"
+];
+const MAX_MEMORY_RESULTS = 10;
+const DEFAULT_MEMORY_RESULTS = 5;
+const MAX_CONTEXT_FILES = 20;
+const MAX_CONTEXT_FILE_BYTES = 12_000;
+
+const MemorySearchInputSchema = z.object({
+  query: z.string().default(""),
+  limit: z.number().int().min(1).max(MAX_MEMORY_RESULTS).default(DEFAULT_MEMORY_RESULTS)
+});
+const RepoContextReadInputSchema = z.object({
+  path: z.string().trim().optional()
+});
+const ArtifactWriteInputSchema = z.object({}).passthrough();
+const EventEmitInputSchema = z.object({
+  level: z.enum(["info", "warn", "error"]).default("info"),
+  type: z
+    .enum([
+      "workflow_claimed",
+      "stage_started",
+      "stage_completed",
+      "stage_failed",
+      "verification",
+      "release",
+      "scheduler",
+      "system",
+      "agent.blocked"
+    ])
+    .default("system"),
+  message: z.string().trim().min(1).max(2_000)
+});
+const SkillLoadInputSchema = z.object({
+  id: z.string().trim().min(1)
+});
 
 export async function runRoleAgent(definition: AgentDefinition, context: AgentRunContext): Promise<AgentRunResult> {
   const policy = {
@@ -158,8 +210,16 @@ async function runLiveOpenAIAgentWithModel(
         }
       )
     : null;
-  const capabilityIds = runtimeCapabilityIds(configuredMcpServers, mcpSession?.active || [], hostedTools);
+  const builtInCapabilityIds = canRegisterBuiltInTools(sdk) ? BUILT_IN_TOOL_IDS : [];
+  const capabilityIds = runtimeCapabilityIds(
+    configuredMcpServers,
+    mcpSession?.active || [],
+    hostedTools,
+    builtInCapabilityIds
+  );
   const preparation = await prepareAgentRun(definition, context, model, capabilityIds);
+  const artifactCapture: { artifact: StageArtifact | null } = { artifact: null };
+  const builtInTools = createBuiltInTools(sdk, definition, context, preparation, artifactCapture);
 
   try {
     const agent = new AgentCtor({
@@ -167,12 +227,13 @@ async function runLiveOpenAIAgentWithModel(
       instructions: definition.instructions,
       model,
       mcpServers: mcpSession?.active || [],
-      tools: hostedTools.map(({ tool }) => tool)
+      tools: [...hostedTools.map(({ tool }) => tool), ...builtInTools.map(({ tool }) => tool)]
     });
 
     const result = await run(agent, preparation.prompt);
     const rawOutput = String(result?.finalOutput ?? result?.output ?? result ?? "");
     const artifact =
+      artifactCapture.artifact ||
       parseLiveArtifact(definition, context, rawOutput, preparation) ||
       createInvalidLiveArtifact(definition, context, rawOutput, preparation);
     return { artifact, rawOutput, live: true };
@@ -232,15 +293,352 @@ function createHostedTools(sdk: any, definition: AgentDefinition, context: Agent
   ];
 }
 
+function canRegisterBuiltInTools(sdk: any): boolean {
+  return typeof sdk.tool === "function" && typeof sdk.toolNamespace === "function";
+}
+
+function createBuiltInTools(
+  sdk: any,
+  definition: AgentDefinition,
+  context: AgentRunContext,
+  preparation: AgentRunPreparation,
+  artifactCapture: { artifact: StageArtifact | null }
+): ConfiguredHostedTool[] {
+  if (!canRegisterBuiltInTools(sdk)) return [];
+
+  const memorySearch = sdk.tool({
+    name: "search",
+    description: "Search scoped durable memory from the current project, repository, work item, or agent.",
+    parameters: MemorySearchInputSchema,
+    execute: async (input: unknown) => searchScopedMemories(context, definition, input)
+  });
+  const repoContextRead = sdk.tool({
+    name: "read",
+    description: "Read files from the configured repo context directory only.",
+    parameters: RepoContextReadInputSchema,
+    execute: async (input: unknown) => readRepoContext(context, input)
+  });
+  const artifactWrite = sdk.tool({
+    name: "write",
+    description: "Validate and capture exactly one StageArtifact for this run.",
+    parameters: ArtifactWriteInputSchema,
+    execute: async (input: unknown) => writeStageArtifact(definition, context, preparation, artifactCapture, input)
+  });
+  const eventEmit = sdk.tool({
+    name: "emit",
+    description: "Emit a scoped workflow event through the current activity handler.",
+    parameters: EventEmitInputSchema,
+    execute: async (input: unknown) => emitScopedEvent(context, input)
+  });
+  const skillLoad = sdk.tool({
+    name: "load",
+    description: "Load one skill by id when it is allowed for the current agent role.",
+    parameters: SkillLoadInputSchema,
+    execute: async (input: unknown) => loadAllowedSkill(definition, context, input)
+  });
+
+  return [
+    ...namespaceTool(sdk, "memory", "Project, repository, work-item, and agent-scoped memory tools.", [
+      { id: "builtin:memory.search", tool: memorySearch }
+    ]),
+    ...namespaceTool(sdk, "repo_context", "Curated connected-repository context tools.", [
+      { id: "builtin:repo.context.read", tool: repoContextRead }
+    ]),
+    ...namespaceTool(sdk, "artifact", "Validated stage artifact tools.", [
+      { id: "builtin:artifact.write", tool: artifactWrite }
+    ]),
+    ...namespaceTool(sdk, "event", "Scoped workflow event tools.", [{ id: "builtin:event.emit", tool: eventEmit }]),
+    ...namespaceTool(sdk, "skill", "Audience-checked skill loading tools.", [
+      { id: "builtin:skill.load", tool: skillLoad }
+    ])
+  ];
+}
+
+function namespaceTool(
+  sdk: any,
+  name: string,
+  description: string,
+  tools: ConfiguredHostedTool[]
+): ConfiguredHostedTool[] {
+  const namespaced = sdk.toolNamespace({
+    name,
+    description,
+    tools: tools.map(({ tool }) => tool)
+  });
+  return tools.map(({ id }, index) => ({ id, tool: namespaced[index] }));
+}
+
+function searchScopedMemories(context: AgentRunContext, definition: AgentDefinition, input: unknown) {
+  const { query, limit } = MemorySearchInputSchema.parse(input);
+  const needle = query.trim().toLowerCase();
+  const records = (context.memories || [])
+    .filter((memory) => memoryMatchesScope(memory, context.workItem, definition))
+    .filter((memory) => {
+      if (!needle) return true;
+      return [memory.title, memory.content, memory.kind, memory.key, ...(memory.tags || [])]
+        .filter(Boolean)
+        .join("\n")
+        .toLowerCase()
+        .includes(needle);
+    })
+    .sort((a, b) => b.importance - a.importance || b.updatedAt.localeCompare(a.updatedAt))
+    .slice(0, limit)
+    .map((memory) => ({
+      id: memory.id,
+      scope: memory.scope,
+      kind: memory.kind,
+      title: memory.title,
+      content: memory.content.slice(0, 2_000),
+      tags: memory.tags,
+      confidence: memory.confidence,
+      importance: memory.importance,
+      updatedAt: memory.updatedAt
+    }));
+
+  return {
+    query,
+    limit,
+    count: records.length,
+    records
+  };
+}
+
+function memoryMatchesScope(memory: MemoryRecord, workItem: WorkItem, definition: AgentDefinition): boolean {
+  if (memory.projectId && memory.projectId !== workItem.projectId) return false;
+  if (memory.repo && memory.repo !== workItem.repo) return false;
+  if (memory.workItemId && memory.workItemId !== workItem.id) return false;
+  if (memory.agent && memory.agent !== definition.role) return false;
+
+  if (memory.scope === "work_item") return memory.workItemId === workItem.id;
+  if (memory.scope === "repo") return Boolean(workItem.repo && memory.repo === workItem.repo);
+  if (memory.scope === "agent") return memory.agent === definition.role;
+  return false;
+}
+
+async function readRepoContext(
+  context: AgentRunContext,
+  input: unknown
+): Promise<{
+  root: string;
+  files?: string[];
+  path?: string;
+  content?: string;
+  truncated?: boolean;
+}> {
+  const { path: requestedPath } = RepoContextReadInputSchema.parse(input);
+  const root = repoContextRoot(context);
+  if (!requestedPath) {
+    return {
+      root: displayRepoContextRoot(context),
+      files: await listContextFiles(root)
+    };
+  }
+
+  const relativePath = normalizeRequestedContextPath(context, requestedPath);
+  const resolved = path.resolve(root, relativePath);
+  assertInside(root, resolved, "repo.context.read path escapes the configured context directory.");
+  const stat = await fs.lstat(resolved);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error("repo.context.read can read regular context files only.");
+  }
+  const buffer = await fs.readFile(resolved);
+  const truncated = buffer.byteLength > MAX_CONTEXT_FILE_BYTES;
+  const content = buffer.subarray(0, MAX_CONTEXT_FILE_BYTES).toString("utf8");
+  return {
+    root: displayRepoContextRoot(context),
+    path: toPosixPath(path.relative(root, resolved)),
+    content,
+    truncated
+  };
+}
+
+async function writeStageArtifact(
+  definition: AgentDefinition,
+  context: AgentRunContext,
+  preparation: AgentRunPreparation,
+  artifactCapture: { artifact: StageArtifact | null },
+  input: unknown
+) {
+  if (artifactCapture.artifact) {
+    throw new Error("artifact.write was already called for this run.");
+  }
+  const record = normalizeRecord(input, "artifact.write");
+  assertArtifactScope(record, context, definition);
+  const summary =
+    typeof record.summary === "string" && record.summary.trim() ? record.summary : "Stage artifact captured.";
+  const bodyJson =
+    typeof record.bodyJson === "object" && record.bodyJson !== null && !Array.isArray(record.bodyJson)
+      ? record.bodyJson
+      : record;
+  const artifact = StageArtifactSchema.parse({
+    ...record,
+    workItemId: context.workItem.id,
+    projectId: context.workItem.projectId,
+    repo: context.workItem.repo,
+    stage: context.stage,
+    ownerAgent: definition.role,
+    title:
+      typeof record.title === "string" && record.title.trim()
+        ? record.title
+        : `${definition.shortName} artifact for ${context.stage}`,
+    summary,
+    nextStage:
+      typeof record.nextStage === "string" || record.nextStage === null
+        ? record.nextStage
+        : inferNextStage(context.stage, context.workItem),
+    promptHash: preparation.promptHash,
+    skillIds: preparation.skills.map((skill) => skill.id),
+    capabilityIds: preparation.capabilityIds,
+    bodyMd:
+      typeof record.bodyMd === "string" && record.bodyMd.trim()
+        ? record.bodyMd
+        : `## ${String(record.title || definition.shortName)}\n\n${summary}`,
+    bodyJson,
+    createdAt: typeof record.createdAt === "string" ? record.createdAt : new Date().toISOString()
+  });
+  artifactCapture.artifact = artifact;
+  return {
+    status: "captured",
+    artifactId: artifact.artifactId,
+    workItemId: artifact.workItemId,
+    stage: artifact.stage
+  };
+}
+
+async function emitScopedEvent(context: AgentRunContext, input: unknown) {
+  if (!context.emitEvent) {
+    throw new Error("event.emit is unavailable for this agent run.");
+  }
+  const event = EventEmitInputSchema.parse(input);
+  await context.emitEvent({
+    level: event.level,
+    type: event.type,
+    message: event.message
+  });
+  return { status: "emitted", type: event.type };
+}
+
+async function loadAllowedSkill(definition: AgentDefinition, context: AgentRunContext, input: unknown) {
+  const { id } = SkillLoadInputSchema.parse(input);
+  const skill = await loadSkillById(
+    {
+      workItem: context.workItem,
+      stage: context.stage,
+      agent: definition.role,
+      targetRepoConfig: context.targetRepoConfig
+    },
+    id
+  );
+  return {
+    id: skill.id,
+    name: skill.name,
+    audience: skill.audience,
+    priority: skill.priority,
+    body: skill.body
+  };
+}
+
+function normalizeRecord(input: unknown, label: string): Record<string, unknown> {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error(`${label} requires an object input.`);
+  }
+  return input as Record<string, unknown>;
+}
+
+function assertArtifactScope(
+  record: Record<string, unknown>,
+  context: AgentRunContext,
+  definition: AgentDefinition
+): void {
+  assertScopeField(record, "workItemId", context.workItem.id);
+  assertScopeField(record, "projectId", context.workItem.projectId);
+  assertScopeField(record, "repo", context.workItem.repo);
+  assertScopeField(record, "stage", context.stage);
+  assertScopeField(record, "ownerAgent", definition.role);
+}
+
+function assertScopeField(record: Record<string, unknown>, field: string, expected: string | undefined): void {
+  const actual = record[field];
+  if (typeof actual === "undefined") return;
+  if (!expected || String(actual) !== expected) {
+    throw new Error(`artifact.write rejected mismatched ${field}.`);
+  }
+}
+
+function repoContextRoot(context: AgentRunContext): string {
+  const repoRoot = path.resolve(context.targetRepoConfig?.repo.localPath || process.cwd());
+  const contextDir = context.targetRepoConfig?.context.defaultContextDir || ".agent-team/context";
+  const root = path.resolve(repoRoot, contextDir);
+  assertInside(repoRoot, root, "Configured context directory escapes the connected repository.");
+  return root;
+}
+
+function displayRepoContextRoot(context: AgentRunContext): string {
+  return toPosixPath(context.targetRepoConfig?.context.defaultContextDir || ".agent-team/context");
+}
+
+function normalizeRequestedContextPath(context: AgentRunContext, requestedPath: string): string {
+  if (path.isAbsolute(requestedPath)) {
+    throw new Error("repo.context.read requires a relative context path.");
+  }
+  const contextDir = toPosixPath(context.targetRepoConfig?.context.defaultContextDir || ".agent-team/context");
+  let normalized = toPosixPath(requestedPath).replace(/^\/+/, "");
+  if (normalized === contextDir) return "";
+  if (normalized.startsWith(`${contextDir}/`)) {
+    normalized = normalized.slice(contextDir.length + 1);
+  }
+  return normalized;
+}
+
+async function listContextFiles(root: string): Promise<string[]> {
+  const files: string[] = [];
+  await collectContextFiles(root, root, files);
+  return files.slice(0, MAX_CONTEXT_FILES);
+}
+
+async function collectContextFiles(root: string, current: string, files: string[]): Promise<void> {
+  if (files.length >= MAX_CONTEXT_FILES) return;
+  let entries: Array<import("node:fs").Dirent>;
+  try {
+    entries = await fs.readdir(current, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (files.length >= MAX_CONTEXT_FILES) return;
+    const fullPath = path.join(current, entry.name);
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) {
+      await collectContextFiles(root, fullPath, files);
+    } else if (entry.isFile()) {
+      assertInside(root, fullPath, "repo.context.read found a file outside the context directory.");
+      files.push(toPosixPath(path.relative(root, fullPath)));
+    }
+  }
+}
+
+function assertInside(root: string, candidate: string, message: string): void {
+  const relative = path.relative(path.resolve(root), path.resolve(candidate));
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(message);
+  }
+}
+
+function toPosixPath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
 function runtimeCapabilityIds(
   configuredMcpServers: ConfiguredMcpServer[],
   activeMcpServers: any[],
-  hostedTools: ConfiguredHostedTool[]
+  hostedTools: ConfiguredHostedTool[],
+  builtInToolIds: string[] = []
 ): string[] {
   const active = new Set(activeMcpServers);
   return [
     ...configuredMcpServers.filter(({ server }) => active.has(server)).map(({ id }) => id),
-    ...hostedTools.map(({ id }) => id)
+    ...hostedTools.map(({ id }) => id),
+    ...builtInToolIds
   ];
 }
 

--- a/packages/agents/src/runner.ts
+++ b/packages/agents/src/runner.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import path from "node:path";
 import { z } from "zod";
 import type { AgentDefinition } from "./definitions";
@@ -437,11 +438,7 @@ async function readRepoContext(
   const relativePath = normalizeRequestedContextPath(context, requestedPath);
   const resolved = path.resolve(root, relativePath);
   assertInside(root, resolved, "repo.context.read path escapes the configured context directory.");
-  const stat = await fs.lstat(resolved);
-  if (!stat.isFile() || stat.isSymbolicLink()) {
-    throw new Error("repo.context.read can read regular context files only.");
-  }
-  const buffer = await fs.readFile(resolved);
+  const buffer = await readRegularContextFile(resolved);
   const truncated = buffer.byteLength > MAX_CONTEXT_FILE_BYTES;
   const content = buffer.subarray(0, MAX_CONTEXT_FILE_BYTES).toString("utf8");
   return {
@@ -450,6 +447,19 @@ async function readRepoContext(
     content,
     truncated
   };
+}
+
+async function readRegularContextFile(resolved: string): Promise<Buffer> {
+  const handle = await fs.open(resolved, readOnlyNoFollowFlags());
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new Error("repo.context.read can read regular context files only.");
+    }
+    return await handle.readFile();
+  } finally {
+    await handle.close();
+  }
 }
 
 async function writeStageArtifact(
@@ -622,6 +632,11 @@ function assertInside(root: string, candidate: string, message: string): void {
   if (relative.startsWith("..") || path.isAbsolute(relative)) {
     throw new Error(message);
   }
+}
+
+function readOnlyNoFollowFlags(): number {
+  const noFollow = (fsConstants as Record<string, number | undefined>).O_NOFOLLOW ?? 0;
+  return fsConstants.O_RDONLY | noFollow;
 }
 
 function toPosixPath(value: string): string {

--- a/packages/agents/src/runner.ts
+++ b/packages/agents/src/runner.ts
@@ -576,7 +576,11 @@ function assertScopeField(record: Record<string, unknown>, field: string, expect
 }
 
 function repoContextRoot(context: AgentRunContext): string {
-  const repoRoot = path.resolve(context.targetRepoConfig?.repo.localPath || process.cwd());
+  const repoLocalPath = context.targetRepoConfig?.repo.localPath?.trim();
+  if (!repoLocalPath) {
+    throw new Error("repo.context.read is unavailable because no connected repository context is configured.");
+  }
+  const repoRoot = path.resolve(repoLocalPath);
   const contextDir = context.targetRepoConfig?.context.defaultContextDir || ".agent-team/context";
   const root = path.resolve(repoRoot, contextDir);
   assertInside(repoRoot, root, "Configured context directory escapes the connected repository.");

--- a/packages/agents/src/skills.ts
+++ b/packages/agents/src/skills.ts
@@ -41,15 +41,7 @@ const MAX_SKILL_BODY_BYTES = 4_096;
 const ABSOLUTE_PATH_REGEX = /^(?:\/|[A-Za-z]:[\\/])/;
 
 export async function loadTriggeredSkills(input: SkillActivationInput): Promise<SkillLoadResult> {
-  const root = path.resolve(process.cwd(), "packages/agents/skills");
-  const files = await findSkillFiles(root);
-  const declaredPluginSkills = pluginSkillFiles(input.targetRepoConfig);
-  const candidates = (
-    await Promise.all([
-      ...files.map(readSkillFile),
-      ...declaredPluginSkills.map(({ declaration, filePath }) => readDeclaredPluginSkillFile(declaration, filePath))
-    ])
-  ).filter((skill): skill is LoadedSkill & { trigger?: SkillFrontmatter["trigger"] } => Boolean(skill));
+  const candidates = await loadSkillCandidates(input.targetRepoConfig);
 
   const active = candidates
     .filter((skill) => skill.audience.includes(input.agent))
@@ -69,6 +61,32 @@ export async function loadTriggeredSkills(input: SkillActivationInput): Promise<
     skills.push(stripTrigger(skill));
   }
   return { skills, droppedSkillIds };
+}
+
+export async function loadSkillById(input: SkillActivationInput, id: string): Promise<LoadedSkill> {
+  const candidates = await loadSkillCandidates(input.targetRepoConfig);
+  const skill = candidates.find((candidate) => candidate.id === id);
+  if (!skill) {
+    throw new Error(`Skill ${id} was not found.`);
+  }
+  if (!skill.audience.includes(input.agent)) {
+    throw new Error(`Skill ${id} is not available to ${input.agent}.`);
+  }
+  return stripTrigger(skill);
+}
+
+async function loadSkillCandidates(
+  config?: TargetRepoConfig
+): Promise<Array<LoadedSkill & { trigger?: SkillFrontmatter["trigger"] }>> {
+  const root = path.resolve(process.cwd(), "packages/agents/skills");
+  const files = await findSkillFiles(root);
+  const declaredPluginSkills = pluginSkillFiles(config);
+  return (
+    await Promise.all([
+      ...files.map(readSkillFile),
+      ...declaredPluginSkills.map(({ declaration, filePath }) => readDeclaredPluginSkillFile(declaration, filePath))
+    ])
+  ).filter((skill): skill is LoadedSkill & { trigger?: SkillFrontmatter["trigger"] } => Boolean(skill));
 }
 
 function pluginSkillFiles(

--- a/tests/agent-prompt-skills.test.ts
+++ b/tests/agent-prompt-skills.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { assembleCanonicalPrompt, getAgentDefinition, loadTriggeredSkills, runRoleAgent } from "../packages/agents/src";
+import {
+  assembleCanonicalPrompt,
+  getAgentDefinition,
+  loadSkillById,
+  loadTriggeredSkills,
+  runRoleAgent
+} from "../packages/agents/src";
 import type { WorkItem } from "../packages/shared/src";
 
 const liveEnvKeys = ["AGENT_LIVE_MODE", "AGENT_EXECUTION_MODE", "AGENT_MODEL", "OPENAI_API_KEY"] as const;
@@ -45,6 +51,7 @@ describe("agent prompt and skills", () => {
     const blocks = [...result.prompt.matchAll(/<<< BLOCK: ([a-z_]+) >>>/g)].map((match) => match[1]);
     expect(blocks).toEqual(["identity", "nonnegotiables", "context", "skills", "tools", "task", "output_contract"]);
     expect(result.prompt).toContain("API contract is ready for frontend consumption.");
+    expect(result.prompt).toContain("repo_context.read");
     expect(result.prompt).not.toContain("accompanying Markdown");
     expect(result.prompt).not.toContain("Markdown body: required");
     expect(result.promptHash).toMatch(/^[a-f0-9]{64}$/);
@@ -64,6 +71,30 @@ describe("agent prompt and skills", () => {
     expect(ids).toContain("react-component-design");
     expect(ids).toContain("accessibility-wcag");
     expect(ids).not.toContain("api-contract-design");
+  });
+
+  it("loads one explicit skill only when the current role is in its audience", async () => {
+    await expect(
+      loadSkillById(
+        {
+          workItem,
+          stage: "BACKEND_BUILD",
+          agent: "backend-systems-engineering"
+        },
+        "api-contract-design"
+      )
+    ).resolves.toMatchObject({ id: "api-contract-design", audience: ["backend-systems-engineering"] });
+
+    await expect(
+      loadSkillById(
+        {
+          workItem,
+          stage: "FRONTEND_BUILD",
+          agent: "frontend-ux-engineering"
+        },
+        "api-contract-design"
+      )
+    ).rejects.toThrow(/not available/);
   });
 
   it("records prompt, skill, and capability provenance on artifacts", async () => {

--- a/tests/agent-runner.test.ts
+++ b/tests/agent-runner.test.ts
@@ -9,6 +9,7 @@ import { DEFAULT_RELEASE_COMMAND, TargetRepoConfigSchema, type WorkItem } from "
 const liveAgentMock = vi.hoisted(() => ({
   models: [] as string[],
   prompts: [] as string[],
+  tools: [] as any[][],
   hostedSearchCalls: 0
 }));
 
@@ -16,9 +17,10 @@ vi.mock("@openai/agents", () => {
   class Agent {
     model: string;
 
-    constructor(options: { model: string }) {
+    constructor(options: { model: string; tools?: any[] }) {
       this.model = options.model;
       liveAgentMock.models.push(options.model);
+      liveAgentMock.tools.push(options.tools || []);
     }
   }
 
@@ -61,7 +63,22 @@ vi.mock("@openai/agents", () => {
     webSearchTool: vi.fn(() => {
       liveAgentMock.hostedSearchCalls += 1;
       return {};
-    })
+    }),
+    tool: vi.fn((options: any) => ({
+      type: "function",
+      name: options.name,
+      description: options.description,
+      parameters: options.parameters,
+      strict: options.strict ?? true,
+      execute: options.execute
+    })),
+    toolNamespace: vi.fn((options: any) =>
+      options.tools.map((tool: any) => ({
+        ...tool,
+        namespace: options.name,
+        qualifiedName: `${options.name}.${tool.name}`
+      }))
+    )
   };
 });
 
@@ -260,11 +277,154 @@ describe("agent runner", () => {
         })
       });
 
-      expect(result.artifact.capabilityIds).toEqual(["mcp:connected-mcp"]);
+      expect(result.artifact.capabilityIds).toEqual(
+        expect.arrayContaining(["mcp:connected-mcp", "builtin:artifact.write"])
+      );
+      expect(result.artifact.capabilityIds).not.toContain("mcp:dropped-mcp");
       expect(liveAgentMock.prompts.at(-1)).toContain("mcp:connected-mcp");
       expect(liveAgentMock.prompts.at(-1)).not.toContain("mcp:dropped-mcp");
     } finally {
       vi.mocked(agents.MCPServers.open).mockReset();
+      restoreEnv("AGENT_LIVE_MODE", originalLiveMode);
+      restoreEnv("OPENAI_API_KEY", originalOpenAiKey);
+      restoreEnv("AGENT_MODEL", originalAgentModel);
+    }
+  });
+
+  it("registers and scopes live runner built-in tools", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-builtins-"));
+    const originalLiveMode = process.env.AGENT_LIVE_MODE;
+    const originalOpenAiKey = process.env.OPENAI_API_KEY;
+    const originalAgentModel = process.env.AGENT_MODEL;
+    const now = new Date().toISOString();
+    liveAgentMock.models.length = 0;
+    liveAgentMock.prompts.length = 0;
+    liveAgentMock.tools.length = 0;
+    liveAgentMock.hostedSearchCalls = 0;
+    process.env.AGENT_LIVE_MODE = "true";
+    process.env.OPENAI_API_KEY = "test-key";
+    process.env.AGENT_MODEL = "gpt-fallback";
+    try {
+      await fs.mkdir(path.join(tempDir, ".agent-team", "context"), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, ".agent-team", "context", "guide.md"),
+        "# Guide\n\nScoped context.",
+        "utf8"
+      );
+      const scopedWorkItem = {
+        ...workItem,
+        id: "WI-TOOLS",
+        projectId: "project-a",
+        repo: "owner/repo",
+        state: "BACKEND_BUILD" as const
+      };
+      const emitted: unknown[] = [];
+      const result = await runRoleAgent(getAgentDefinition("backend-systems-engineering"), {
+        workItem: scopedWorkItem,
+        stage: "BACKEND_BUILD",
+        previousArtifacts: [],
+        targetRepoConfig: liveTargetConfig({ repoPath: tempDir }),
+        memories: [
+          {
+            id: "mem-1",
+            scope: "work_item",
+            projectId: "project-a",
+            repo: "owner/repo",
+            workItemId: "WI-TOOLS",
+            kind: "decision",
+            title: "Use strict tools",
+            content: "Built-in tool results must stay scoped.",
+            tags: ["tools"],
+            confidence: "high",
+            importance: 5,
+            permanence: "durable",
+            source: "test",
+            createdAt: now,
+            updatedAt: now
+          },
+          {
+            id: "mem-2",
+            scope: "work_item",
+            projectId: "other-project",
+            repo: "owner/repo",
+            workItemId: "WI-OTHER",
+            kind: "decision",
+            title: "Do not leak",
+            content: "This memory belongs to another project.",
+            tags: [],
+            confidence: "high",
+            importance: 5,
+            permanence: "durable",
+            source: "test",
+            createdAt: now,
+            updatedAt: now
+          }
+        ],
+        emitEvent: async (event) => {
+          emitted.push(event);
+        }
+      });
+
+      expect(result.artifact.capabilityIds).toEqual(
+        expect.arrayContaining([
+          "builtin:memory.search",
+          "builtin:repo.context.read",
+          "builtin:artifact.write",
+          "builtin:event.emit",
+          "builtin:skill.load"
+        ])
+      );
+      const tools = liveAgentMock.tools.at(-1) || [];
+      const toolNames = tools.map((tool) => tool.qualifiedName || `${tool.namespace}.${tool.name}`);
+      expect(toolNames).toEqual(
+        expect.arrayContaining(["memory.search", "repo_context.read", "artifact.write", "event.emit", "skill.load"])
+      );
+
+      await expect(findTool(tools, "memory.search").execute({ query: "strict", limit: 5 })).resolves.toMatchObject({
+        count: 1,
+        records: [expect.objectContaining({ id: "mem-1" })]
+      });
+
+      const repoTool = findTool(tools, "repo_context.read");
+      await expect(repoTool.execute({ path: "guide.md" })).resolves.toMatchObject({
+        path: "guide.md",
+        content: expect.stringContaining("Scoped context.")
+      });
+      await expect(repoTool.execute({ path: "../package.json" })).rejects.toThrow(/escapes/);
+
+      const artifactTool = findTool(tools, "artifact.write");
+      await expect(artifactTool.execute({ workItemId: "wrong", title: "Bad", summary: "Bad" })).rejects.toThrow(
+        /mismatched workItemId/
+      );
+      await expect(
+        artifactTool.execute({
+          title: "Backend built-in tools ready",
+          summary: "Built-in tools were validated.",
+          status: "passed",
+          decisions: ["Use runner-owned tools."],
+          risks: [],
+          filesChanged: ["packages/agents/src/runner.ts"],
+          testsRun: ["agent-runner"],
+          releaseReadiness: "unknown",
+          nextStage: "INTEGRATION",
+          bodyMd: "## Backend built-in tools ready",
+          bodyJson: { ok: true }
+        })
+      ).resolves.toMatchObject({ status: "captured", workItemId: "WI-TOOLS" });
+
+      await expect(
+        findTool(tools, "event.emit").execute({ type: "agent.blocked", level: "warn", message: "Need routing." })
+      ).resolves.toEqual({ status: "emitted", type: "agent.blocked" });
+      expect(emitted).toContainEqual({ type: "agent.blocked", level: "warn", message: "Need routing." });
+
+      const skillTool = findTool(tools, "skill.load");
+      await expect(skillTool.execute({ id: "api-contract-design" })).resolves.toMatchObject({
+        id: "api-contract-design",
+        audience: ["backend-systems-engineering"]
+      });
+      await expect(skillTool.execute({ id: "react-component-design" })).rejects.toThrow(/not available/);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
       restoreEnv("AGENT_LIVE_MODE", originalLiveMode);
       restoreEnv("OPENAI_API_KEY", originalOpenAiKey);
       restoreEnv("AGENT_MODEL", originalAgentModel);
@@ -370,6 +530,16 @@ Use the plugin-provided browser smoke procedure when the work item requires UI r
     }
   });
 });
+
+function findTool(tools: any[], qualifiedName: string): any {
+  const tool = tools.find(
+    (candidate) => (candidate.qualifiedName || `${candidate.namespace}.${candidate.name}`) === qualifiedName
+  );
+  if (!tool) {
+    throw new Error(`Tool ${qualifiedName} was not registered.`);
+  }
+  return tool;
+}
 
 function liveTargetConfig(
   overrides: {

--- a/tests/agent-runner.test.ts
+++ b/tests/agent-runner.test.ts
@@ -431,6 +431,35 @@ describe("agent runner", () => {
     }
   });
 
+  it("fails closed when repo context is requested without a connected repo", async () => {
+    const originalLiveMode = process.env.AGENT_LIVE_MODE;
+    const originalOpenAiKey = process.env.OPENAI_API_KEY;
+    const originalAgentModel = process.env.AGENT_MODEL;
+    liveAgentMock.models.length = 0;
+    liveAgentMock.prompts.length = 0;
+    liveAgentMock.tools.length = 0;
+    liveAgentMock.hostedSearchCalls = 0;
+    process.env.AGENT_LIVE_MODE = "true";
+    process.env.OPENAI_API_KEY = "test-key";
+    process.env.AGENT_MODEL = "gpt-fallback";
+    try {
+      await runRoleAgent(getAgentDefinition("backend-systems-engineering"), {
+        workItem: { ...workItem, state: "BACKEND_BUILD" },
+        stage: "BACKEND_BUILD",
+        previousArtifacts: []
+      });
+
+      const tools = liveAgentMock.tools.at(-1) || [];
+      await expect(findTool(tools, "repo_context.read").execute({ path: "guide.md" })).rejects.toThrow(
+        /no connected repository context/
+      );
+    } finally {
+      restoreEnv("AGENT_LIVE_MODE", originalLiveMode);
+      restoreEnv("OPENAI_API_KEY", originalOpenAiKey);
+      restoreEnv("AGENT_MODEL", originalAgentModel);
+    }
+  });
+
   it("preserves successful agent results when MCP close fails", async () => {
     const originalLiveMode = process.env.AGENT_LIVE_MODE;
     const originalOpenAiKey = process.env.OPENAI_API_KEY;


### PR DESCRIPTION
## Summary

- Registers runner-owned built-in tools for live OpenAI agent runs: `memory.search`, `repo_context.read`, `artifact.write`, `event.emit`, and `skill.load`.
- Keeps tool behavior scoped to the current project/repo/work item and validates artifacts through `StageArtifactSchema`.
- Bridges worker activity event emission into live agent runs and adds explicit skill-by-id loading with audience checks.

## Scope

Closes #89.

## Validation

- `npm test -- tests/agent-runner.test.ts tests/agent-prompt-skills.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run check`
- `npm run logs:check`
- `docker compose config --no-interpolate --quiet`
- `git diff --check`

## Risk

Medium: live-runner tool registration path changes, but tool access is additive, scoped, and covered by focused tests plus the full repo check.

## Rollback

Revert this PR to return live runs to hosted/MCP tools plus final-output parsing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents can emit structured runtime events (including blocking/failure events) into the controller.
  * Built-in agent capabilities added: memory search, repo-context read, artifact write, event emit, and skill load.
  * Ability to query/load individual skills with audience/authorization checks.

* **Improvements**
  * Richer event metadata and severity handling for better visibility and tracing.

* **Tests**
  * Expanded test coverage validating prompt assembly, built-in tools, capability registration, scope/permission checks, and skill-loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->