### PR TITLE
Codex Cloud Backend/Core: [Codex Queue] Reject INTAKE to VERIFY state transition

### DIFF
--- a/packages/shared/src/state-machine.ts
+++ b/packages/shared/src/state-machine.ts
@@ -23,7 +23,7 @@ export const TERMINAL_WORK_ITEM_STATES: WorkItemState[] = ["CLOSED", "BLOCKED"];
 
 const transitions: Record<WorkItemState, WorkItemState[]> = {
   NEW: ["INTAKE", "BLOCKED"],
-  INTAKE: ["RND", "CONTRACT", "VERIFY", "BLOCKED"],
+  INTAKE: ["RND", "CONTRACT", "BLOCKED"],
   RND: ["PROPOSAL", "CONTRACT", "BLOCKED"],
   PROPOSAL: ["AWAITING_ACCEPTANCE", "CONTRACT", "RND", "CLOSED", "BLOCKED"],
   AWAITING_ACCEPTANCE: ["CONTRACT", "RND", "CLOSED", "BLOCKED"],

--- a/tests/state-machine.test.ts
+++ b/tests/state-machine.test.ts
@@ -28,6 +28,14 @@ describe("work item state machine", () => {
     expect(canTransition("CLOSED", "RELEASE")).toBe(false);
   });
 
+  it("keeps intake routing aligned with the spec-backed states", () => {
+    expect(nextStates("INTAKE")).toEqual(["RND", "CONTRACT", "BLOCKED"]);
+    expect(canTransition("INTAKE", "RND")).toBe(true);
+    expect(canTransition("INTAKE", "CONTRACT")).toBe(true);
+    expect(canTransition("INTAKE", "BLOCKED")).toBe(true);
+    expect(canTransition("INTAKE", "VERIFY")).toBe(false);
+  });
+
   it("keeps blocked state explicit outside the happy path", () => {
     expect(WORKFLOW_SEQUENCE).not.toContain("BLOCKED");
     expect(ALL_WORK_ITEM_STATES).toContain("BLOCKED");


### PR DESCRIPTION
## Summary

Codex Cloud Backend/Core implemented queued issue #100.

Closes #100

## Scope

[Codex Queue] Reject INTAKE to VERIFY state transition

## Validation

- npm run check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- git diff --check

## Automation

- Stage: Backend/Core
- Run: https://github.com/onfire7777/five-agent-dev-team/actions/runs/25349397809
- Target: #100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected the intake workflow routing to align with specification requirements. Intake now properly transitions through RND, CONTRACT, or BLOCKED states, preventing invalid direct routing to VERIFY status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->