### PR TITLE
Harden Captain merge gate against policy-blocked PRs

### DIFF
--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -663,6 +663,11 @@ jobs:
         run: |
           gh pr view "$PR_NUMBER" --json number,title,isDraft,mergeStateStatus,reviewDecision,labels,headRefOid,url
           gh pr checks "$PR_NUMBER" --required --watch
+          merge_state="$(gh pr view "$PR_NUMBER" --json mergeStateStatus --jq '.mergeStateStatus')"
+          if [ "$merge_state" != "CLEAN" ] && [ "$merge_state" != "HAS_HOOKS" ]; then
+            echo "Captain no-op: PR #$PR_NUMBER is not merge-ready after required checks; mergeStateStatus=$merge_state"
+            exit 0
+          fi
           head_sha="$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')"
           target_issues="$(gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[].number' || true)"
           gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$head_sha"


### PR DESCRIPTION
## Summary

Captain now exits cleanly when GitHub still reports a ready PR as policy-blocked after required-check waiting. This prevents scheduled Captain runs from producing avoidable workflow failures while the workflow_run Captain pass can merge after CI is actually complete.

## Validation

- npm run format:check
- git diff --check

## Automation

- Scope: cloud Codex build pipeline Captain merge gate
- Risk: low; only changes the not-yet-mergeable path from failed run to no-op

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved merge validation in the CI/CD pipeline with enhanced state checks to ensure more reliable merge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->