### PR TITLE
Handle duplicate Captain merge attempts

### DIFF
--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -670,7 +670,14 @@ jobs:
           fi
           head_sha="$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')"
           target_issues="$(gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[].number' || true)"
-          gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$head_sha"
+          if ! merge_output="$(gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$head_sha" 2>&1)"; then
+            if echo "$merge_output" | grep -Eiq "merge already in progress|already merged"; then
+              echo "Captain no-op: PR #$PR_NUMBER merge is already handled by another Captain run."
+              exit 0
+            fi
+            echo "$merge_output" >&2
+            exit 1
+          fi
 
           for issue_number in $target_issues; do
             gh issue edit "$issue_number" --add-label agent:done || true


### PR DESCRIPTION
## Summary

Captain now treats duplicate merge attempts as a clean no-op when another Captain run has already started or completed the same PR merge. This removes avoidable workflow_run failures from concurrent CI-completion events while preserving expected-head merge safety for real merge errors.

## Validation

- npm run format:check
- git diff --check

## Automation

- Scope: Codex Cloud Build Pipeline Captain merge gate
- Risk: low; only changes duplicate merge race handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced merge gate workflow to gracefully handle concurrent merge operations, preventing unnecessary failures when pull requests are already being merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->