### PR TITLE
Let Captain update behind cloud PRs

### DIFF
--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -664,6 +664,11 @@ jobs:
           gh pr view "$PR_NUMBER" --json number,title,isDraft,mergeStateStatus,reviewDecision,labels,headRefOid,url
           gh pr checks "$PR_NUMBER" --required --watch
           merge_state="$(gh pr view "$PR_NUMBER" --json mergeStateStatus --jq '.mergeStateStatus')"
+          if [ "$merge_state" = "BEHIND" ]; then
+            echo "Captain updating PR #$PR_NUMBER because it is behind main."
+            gh pr update-branch "$PR_NUMBER"
+            exit 0
+          fi
           if [ "$merge_state" != "CLEAN" ] && [ "$merge_state" != "HAS_HOOKS" ]; then
             echo "Captain no-op: PR #$PR_NUMBER is not merge-ready after required checks; mergeStateStatus=$merge_state"
             exit 0

--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -666,7 +666,14 @@ jobs:
           merge_state="$(gh pr view "$PR_NUMBER" --json mergeStateStatus --jq '.mergeStateStatus')"
           if [ "$merge_state" = "BEHIND" ]; then
             echo "Captain updating PR #$PR_NUMBER because it is behind main."
-            gh pr update-branch "$PR_NUMBER"
+            if ! update_output="$(gh pr update-branch "$PR_NUMBER" 2>&1)"; then
+              if echo "$update_output" | grep -Eiq "already (up to date|in progress)|update.*in progress"; then
+                echo "Captain no-op: $update_output"
+                exit 0
+              fi
+              echo "$update_output" >&2
+              exit 1
+            fi
             exit 0
           fi
           if [ "$merge_state" != "CLEAN" ] && [ "$merge_state" != "HAS_HOOKS" ]; then


### PR DESCRIPTION
## Summary

Captain now updates a ready cloud PR branch when GitHub reports mergeStateStatus=BEHIND, then exits cleanly so CI can rerun on the refreshed head. This removes a manual intervention point from the continuous loop.

## Validation

- npm run format:check
- git diff --check

## Automation

- Scope: Codex Cloud Build Pipeline Captain merge gate
- Risk: low; only changes the BEHIND branch state path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the merge gate to detect PRs that are out of sync and automatically attempt to update their branches before evaluating merge readiness; benign "already up to date" or "update in progress" responses are treated as successful, while other update failures surface as errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->