### PR TITLE
Codex Cloud Backend/Core: [Codex Queue] Add project-scoped emergency stop enforcement

### DIFF
--- a/apps/controller/src/index.ts
+++ b/apps/controller/src/index.ts
@@ -1914,17 +1914,10 @@ app.post("/api/emergency-resume", async (req, res, next) => {
 });
 
 function emergencyControlTarget(input: EmergencyControlRequest): { responseScope: string; projectId?: string } {
-  const requestedScope = input.scope.trim();
-  if (requestedScope === "global") {
-    if (input.projectId) throw new HttpError("projectId is only allowed for project emergency controls.", 400);
+  if (input.scope === "global") {
     return { responseScope: "global" };
   }
-  const embeddedProjectId = requestedScope.startsWith("project:")
-    ? requestedScope.slice("project:".length).trim()
-    : undefined;
-  const projectId = input.projectId || embeddedProjectId || (requestedScope === "project" ? undefined : requestedScope);
-  if (!projectId) throw new HttpError("projectId is required for project emergency controls.", 400);
-  return { responseScope: `project:${projectId}`, projectId };
+  return { responseScope: `project:${input.projectId}`, projectId: input.projectId };
 }
 
 app.use((error: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/apps/controller/src/index.ts
+++ b/apps/controller/src/index.ts
@@ -1719,8 +1719,15 @@ async function startWorkflowIfSafe(
     }
   }
 
-  const claimed = await store.claimWorkItemForWorkflow(workItem.id);
-  if (!claimed) {
+  const claim = await store.claimWorkItemForWorkflowIfNotStopped(workItem.id, workItem.projectId);
+  if (claim.emergencyStop?.active) {
+    return {
+      workflowId: null,
+      queued: true,
+      reason: claim.emergencyStop.reason || "Emergency stop is active"
+    };
+  }
+  if (!claim.claimed) {
     return { workflowId: null, queued: true, reason: "Work item is already claimed by a workflow." };
   }
 
@@ -1894,7 +1901,7 @@ async function requireConnectedProjectForWork(input: z.infer<typeof CreateWorkIt
 app.post("/api/emergency-stop", async (req, res, next) => {
   try {
     const input = EmergencyControlRequestSchema.parse(req.body);
-    const target = emergencyControlTarget(input);
+    const target = await emergencyControlTarget(input);
     await store.setEmergencyStop(true, input.reason, target.projectId);
     res.json({ emergencyStop: true, scope: target.responseScope, projectId: target.projectId, reason: input.reason });
   } catch (error) {
@@ -1905,7 +1912,7 @@ app.post("/api/emergency-stop", async (req, res, next) => {
 app.post("/api/emergency-resume", async (req, res, next) => {
   try {
     const input = EmergencyControlRequestSchema.parse(req.body);
-    const target = emergencyControlTarget(input);
+    const target = await emergencyControlTarget(input);
     await store.setEmergencyStop(false, input.reason, target.projectId);
     res.json({ emergencyStop: false, scope: target.responseScope, projectId: target.projectId, reason: input.reason });
   } catch (error) {
@@ -1913,11 +1920,14 @@ app.post("/api/emergency-resume", async (req, res, next) => {
   }
 });
 
-function emergencyControlTarget(input: EmergencyControlRequest): { responseScope: string; projectId?: string } {
+async function emergencyControlTarget(
+  input: EmergencyControlRequest
+): Promise<{ responseScope: string; projectId?: string }> {
   if (input.scope === "global") {
     return { responseScope: "global" };
   }
-  return { responseScope: `project:${input.projectId}`, projectId: input.projectId };
+  const project = await requireScopeForProjectId(input.projectId);
+  return { responseScope: `project:${project.projectId}`, projectId: project.projectId };
 }
 
 app.use((error: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/apps/controller/src/index.ts
+++ b/apps/controller/src/index.ts
@@ -31,6 +31,7 @@ import {
   WorkItemStateSchema,
   loadTargetRepoConfig,
   targetRepoConfigFromProjectConnection,
+  type EmergencyControlRequest,
   type ProjectCapabilityStatus,
   type ProjectConnection,
   type ProjectConnectionInput,
@@ -160,7 +161,8 @@ const WorkItemProposalDecisionRequest = z.object({
 });
 
 export const app = express();
-const store = createStore();
+export const controllerStore = createStore();
+const store = controllerStore;
 const port = Number(process.env.PORT || 4310);
 const host = process.env.HOST || "127.0.0.1";
 const execFile = util.promisify(childProcess.execFile);
@@ -1690,15 +1692,16 @@ async function decideWorkItemProposal(workItemId: string, decision: "accept" | "
 async function startWorkflowIfSafe(
   workItem: WorkItem
 ): Promise<{ workflowId: string | null; queued: boolean; reason?: string }> {
-  const status = await store.getStatus();
-  if (status.system.emergencyStop) {
+  const emergencyStop = await store.getEmergencyStop(workItem.projectId);
+  if (emergencyStop.active) {
     return {
       workflowId: null,
       queued: true,
-      reason: status.system.emergencyReason || "Emergency stop is active"
+      reason: emergencyStop.reason || "Emergency stop is active"
     };
   }
 
+  const status = await store.getStatus();
   if (workItem.projectId && workItem.repo) {
     const activeSameProject = status.workItems.some(
       (item) =>
@@ -1891,8 +1894,9 @@ async function requireConnectedProjectForWork(input: z.infer<typeof CreateWorkIt
 app.post("/api/emergency-stop", async (req, res, next) => {
   try {
     const input = EmergencyControlRequestSchema.parse(req.body);
-    await store.setEmergencyStop(true, `[${input.scope}] ${input.reason}`);
-    res.json({ emergencyStop: true, scope: input.scope, reason: input.reason });
+    const target = emergencyControlTarget(input);
+    await store.setEmergencyStop(true, input.reason, target.projectId);
+    res.json({ emergencyStop: true, scope: target.responseScope, projectId: target.projectId, reason: input.reason });
   } catch (error) {
     next(error);
   }
@@ -1901,12 +1905,27 @@ app.post("/api/emergency-stop", async (req, res, next) => {
 app.post("/api/emergency-resume", async (req, res, next) => {
   try {
     const input = EmergencyControlRequestSchema.parse(req.body);
-    await store.setEmergencyStop(false);
-    res.json({ emergencyStop: false, scope: input.scope, reason: input.reason });
+    const target = emergencyControlTarget(input);
+    await store.setEmergencyStop(false, input.reason, target.projectId);
+    res.json({ emergencyStop: false, scope: target.responseScope, projectId: target.projectId, reason: input.reason });
   } catch (error) {
     next(error);
   }
 });
+
+function emergencyControlTarget(input: EmergencyControlRequest): { responseScope: string; projectId?: string } {
+  const requestedScope = input.scope.trim();
+  if (requestedScope === "global") {
+    if (input.projectId) throw new HttpError("projectId is only allowed for project emergency controls.", 400);
+    return { responseScope: "global" };
+  }
+  const embeddedProjectId = requestedScope.startsWith("project:")
+    ? requestedScope.slice("project:".length).trim()
+    : undefined;
+  const projectId = input.projectId || embeddedProjectId || (requestedScope === "project" ? undefined : requestedScope);
+  if (!projectId) throw new HttpError("projectId is required for project emergency controls.", 400);
+  return { responseScope: `project:${projectId}`, projectId };
+}
 
 app.use((error: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
   const message = error instanceof Error ? error.message : "Unknown error";

--- a/apps/controller/src/store.ts
+++ b/apps/controller/src/store.ts
@@ -102,6 +102,13 @@ type ProjectConnectionPersistInput = ProjectConnectionInput &
   >;
 
 export type StrictProjectScope = { projectId: string; repo: string };
+export type EmergencyStopStatus = {
+  active: boolean;
+  reason: string;
+  scope: "global" | "project";
+  projectId?: string;
+  updatedAt?: string;
+};
 
 export type TeamBusMessage = StrictProjectScope & {
   id: string;
@@ -262,7 +269,8 @@ export interface ControllerStore {
   claimWorkItemForWorkflow(id: string): Promise<boolean>;
   listWorkflowClaims(): Promise<string[]>;
   releaseWorkItemWorkflowClaim(id: string): Promise<void>;
-  setEmergencyStop(active: boolean, reason?: string): Promise<void>;
+  getEmergencyStop(projectId?: string): Promise<EmergencyStopStatus>;
+  setEmergencyStop(active: boolean, reason?: string, projectId?: string): Promise<void>;
 }
 
 export class MemoryStore implements ControllerStore {
@@ -279,8 +287,7 @@ export class MemoryStore implements ControllerStore {
   private events: AgentEvent[] = [];
   private nextEventSequence = 1;
   private workflowClaims = new Set<string>();
-  private emergencyStop = false;
-  private emergencyReason = "";
+  private emergencyStops = new Map<string, EmergencyStopStatus>();
 
   async init(): Promise<void> {
     await this.seedConfiguredProjectConnection();
@@ -288,13 +295,14 @@ export class MemoryStore implements ControllerStore {
   }
 
   async getStatus() {
+    const emergencyStop = await this.getEmergencyStop();
     return buildControllerStatus({
       workItems: this.workItems,
       artifacts: this.artifacts,
       events: this.events,
       projectConnections: await this.listProjectConnections(),
-      emergencyStop: this.emergencyStop,
-      emergencyReason: this.emergencyReason
+      emergencyStop: emergencyStop.active,
+      emergencyReason: emergencyStop.reason
     });
   }
 
@@ -707,9 +715,21 @@ export class MemoryStore implements ControllerStore {
     this.workflowClaims.delete(id);
   }
 
-  async setEmergencyStop(active: boolean, reason = ""): Promise<void> {
-    this.emergencyStop = active;
-    this.emergencyReason = active ? reason : "";
+  async getEmergencyStop(projectId?: string): Promise<EmergencyStopStatus> {
+    const globalStop = this.emergencyStops.get(emergencyStopKey());
+    if (globalStop?.active) return globalStop;
+    if (!projectId) return globalStop || inactiveEmergencyStop();
+    return this.emergencyStops.get(emergencyStopKey(projectId)) || inactiveEmergencyStop(projectId);
+  }
+
+  async setEmergencyStop(active: boolean, reason = "", projectId?: string): Promise<void> {
+    this.emergencyStops.set(emergencyStopKey(projectId), {
+      active,
+      reason: active ? reason : "",
+      scope: projectId ? "project" : "global",
+      projectId,
+      updatedAt: new Date().toISOString()
+    });
   }
 
   private async seedConfiguredProjectConnection(): Promise<void> {
@@ -788,7 +808,7 @@ export class PostgresStore extends MemoryStore {
     const workItems = await this.listWorkItems();
     const artifacts = await this.listArtifacts();
     const events = await this.listEvents(0, 50);
-    const emergencyStop = await this.readEmergencyStopFlag();
+    const emergencyStop = await this.getEmergencyStop();
     return buildControllerStatus({
       workItems,
       artifacts,
@@ -1335,26 +1355,39 @@ export class PostgresStore extends MemoryStore {
     return resolveProjectScopeFromConnections(input, connections) || resolveConfiguredProject();
   }
 
-  override async setEmergencyStop(active: boolean, reason = ""): Promise<void> {
-    await this.pool.query(
-      "insert into controller_flags (key, value) values ('emergency_stop', $1) on conflict (key) do update set value = excluded.value",
-      [{ active, reason, updatedAt: new Date().toISOString() }]
+  override async getEmergencyStop(projectId?: string): Promise<EmergencyStopStatus> {
+    const keys = projectId ? [emergencyStopKey(), emergencyStopKey(projectId)] : [emergencyStopKey()];
+    const result = await this.pool.query<{ key: string; value: unknown }>(
+      "select key, value from controller_flags where key = any($1::text[])",
+      [keys]
     );
-    await super.setEmergencyStop(active, reason);
+    const valuesByKey = new Map(result.rows.map((row) => [row.key, row.value]));
+    const globalStop = emergencyStopStatusFromValue(valuesByKey.get(emergencyStopKey()));
+    if (globalStop.active) return globalStop;
+    if (!projectId) return globalStop;
+    return emergencyStopStatusFromValue(valuesByKey.get(emergencyStopKey(projectId)), projectId);
+  }
+
+  override async setEmergencyStop(active: boolean, reason = "", projectId?: string): Promise<void> {
+    await this.pool.query(
+      "insert into controller_flags (key, value) values ($1, $2) on conflict (key) do update set value = excluded.value",
+      [
+        emergencyStopKey(projectId),
+        {
+          active,
+          reason: active ? reason : "",
+          scope: projectId ? "project" : "global",
+          projectId,
+          updatedAt: new Date().toISOString()
+        }
+      ]
+    );
+    await super.setEmergencyStop(active, reason, projectId);
   }
 
   private async listArtifacts(): Promise<StageArtifact[]> {
     const result = await this.pool.query("select payload from stage_artifacts order by created_at desc");
     return result.rows.map((row) => StageArtifactSchema.parse(row.payload));
-  }
-
-  private async readEmergencyStopFlag(): Promise<{ active: boolean; reason: string }> {
-    const result = await this.pool.query("select value from controller_flags where key = 'emergency_stop'");
-    if (!result.rows[0]) return { active: false, reason: "" };
-    return {
-      active: Boolean(result.rows[0].value?.active),
-      reason: String(result.rows[0].value?.reason || "")
-    };
   }
 
   private async seedProjectConnectionsFromConfig(): Promise<void> {
@@ -1376,6 +1409,31 @@ export function createStore(): ControllerStore {
     return new PostgresStore(process.env.DATABASE_URL);
   }
   return new MemoryStore();
+}
+
+function emergencyStopKey(projectId?: string): string {
+  return projectId ? `emergency_stop:project:${projectId}` : "emergency_stop";
+}
+
+function inactiveEmergencyStop(projectId?: string): EmergencyStopStatus {
+  return {
+    active: false,
+    reason: "",
+    scope: projectId ? "project" : "global",
+    projectId
+  };
+}
+
+function emergencyStopStatusFromValue(value: unknown, projectId?: string): EmergencyStopStatus {
+  if (!value || typeof value !== "object") return inactiveEmergencyStop(projectId);
+  const payload = value as Record<string, unknown>;
+  return {
+    active: Boolean(payload.active),
+    reason: typeof payload.reason === "string" ? payload.reason : "",
+    scope: projectId ? "project" : "global",
+    projectId,
+    updatedAt: typeof payload.updatedAt === "string" ? payload.updatedAt : undefined
+  };
 }
 
 function buildControllerStatus(input: {

--- a/apps/controller/src/store.ts
+++ b/apps/controller/src/store.ts
@@ -109,6 +109,10 @@ export type EmergencyStopStatus = {
   projectId?: string;
   updatedAt?: string;
 };
+export type WorkflowClaimResult = {
+  claimed: boolean;
+  emergencyStop?: EmergencyStopStatus;
+};
 
 export type TeamBusMessage = StrictProjectScope & {
   id: string;
@@ -267,6 +271,7 @@ export interface ControllerStore {
   upsertProposal(scope: StrictProjectScope, input: ProposalInput): Promise<Proposal>;
   decideProposal(scope: StrictProjectScope, proposalId: string, input: ProposalDecisionInput): Promise<Proposal>;
   claimWorkItemForWorkflow(id: string): Promise<boolean>;
+  claimWorkItemForWorkflowIfNotStopped(id: string, projectId?: string): Promise<WorkflowClaimResult>;
   listWorkflowClaims(): Promise<string[]>;
   releaseWorkItemWorkflowClaim(id: string): Promise<void>;
   getEmergencyStop(projectId?: string): Promise<EmergencyStopStatus>;
@@ -707,6 +712,12 @@ export class MemoryStore implements ControllerStore {
     return true;
   }
 
+  async claimWorkItemForWorkflowIfNotStopped(id: string, projectId?: string): Promise<WorkflowClaimResult> {
+    const emergencyStop = await this.getEmergencyStop(projectId);
+    if (emergencyStop.active) return { claimed: false, emergencyStop };
+    return { claimed: await this.claimWorkItemForWorkflow(id) };
+  }
+
   async listWorkflowClaims(): Promise<string[]> {
     return [...this.workflowClaims];
   }
@@ -985,6 +996,46 @@ export class PostgresStore extends MemoryStore {
       [id]
     );
     return result.rowCount === 1;
+  }
+
+  override async claimWorkItemForWorkflowIfNotStopped(id: string, projectId?: string): Promise<WorkflowClaimResult> {
+    const keys = [emergencyStopKey(), ...(projectId ? [emergencyStopKey(projectId)] : [])].sort();
+    const client = await this.pool.connect();
+    try {
+      await client.query("begin");
+      for (const key of keys) {
+        await client.query("select pg_advisory_xact_lock(hashtext($1)::bigint)", [key]);
+      }
+      const flags = await client.query<{ key: string; value: unknown }>(
+        "select key, value from controller_flags where key = any($1::text[])",
+        [keys]
+      );
+      const valuesByKey = new Map(flags.rows.map((row) => [row.key, row.value]));
+      const globalStop = emergencyStopStatusFromValue(valuesByKey.get(emergencyStopKey()));
+      const projectStop = projectId
+        ? emergencyStopStatusFromValue(valuesByKey.get(emergencyStopKey(projectId)), projectId)
+        : inactiveEmergencyStop();
+      const emergencyStop = globalStop.active ? globalStop : projectStop;
+      if (emergencyStop.active) {
+        await client.query("commit");
+        return { claimed: false, emergencyStop };
+      }
+      const result = await client.query(
+        "insert into workflow_claims (work_item_id) values ($1) on conflict do nothing returning work_item_id",
+        [id]
+      );
+      await client.query("commit");
+      return { claimed: result.rowCount === 1 };
+    } catch (error) {
+      try {
+        await client.query("rollback");
+      } catch (rollbackError) {
+        console.warn("Workflow claim rollback failed.", rollbackError);
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   override async listWorkflowClaims(): Promise<string[]> {
@@ -1369,19 +1420,35 @@ export class PostgresStore extends MemoryStore {
   }
 
   override async setEmergencyStop(active: boolean, reason = "", projectId?: string): Promise<void> {
-    await this.pool.query(
-      "insert into controller_flags (key, value) values ($1, $2) on conflict (key) do update set value = excluded.value",
-      [
-        emergencyStopKey(projectId),
-        {
-          active,
-          reason: active ? reason : "",
-          scope: projectId ? "project" : "global",
-          projectId,
-          updatedAt: new Date().toISOString()
-        }
-      ]
-    );
+    const key = emergencyStopKey(projectId);
+    const client = await this.pool.connect();
+    try {
+      await client.query("begin");
+      await client.query("select pg_advisory_xact_lock(hashtext($1)::bigint)", [key]);
+      await client.query(
+        "insert into controller_flags (key, value) values ($1, $2) on conflict (key) do update set value = excluded.value",
+        [
+          key,
+          {
+            active,
+            reason: active ? reason : "",
+            scope: projectId ? "project" : "global",
+            projectId,
+            updatedAt: new Date().toISOString()
+          }
+        ]
+      );
+      await client.query("commit");
+    } catch (error) {
+      try {
+        await client.query("rollback");
+      } catch (rollbackError) {
+        console.warn("Emergency stop rollback failed.", rollbackError);
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
     await super.setEmergencyStop(active, reason, projectId);
   }
 

--- a/apps/worker/src/activities.ts
+++ b/apps/worker/src/activities.ts
@@ -77,10 +77,20 @@ type LoopEvidence = {
   github: EvidenceItem;
 };
 
-export async function ensureNotStopped(workItemId: string, config?: TargetRepoConfig): Promise<void> {
+export async function ensureNotStopped(
+  workItemId: string,
+  configOrProjectId?: TargetRepoConfig | string,
+  projectId?: string
+): Promise<void> {
+  const config = typeof configOrProjectId === "string" ? undefined : configOrProjectId;
+  const scopedProjectId = typeof configOrProjectId === "string" ? configOrProjectId : projectId;
   const store = await getActivityStore();
-  const status = await store.getStatus();
-  if (status.system.emergencyStop) {
+  const stop = await store.getEmergencyStop(
+    scopedProjectId ||
+      (config ? projectIdForConfig(config) : undefined) ||
+      (await projectIdForWorkItem(store, workItemId))
+  );
+  if (stop.active) {
     throw new Error(`Emergency stop is active. Work item ${workItemId} cannot continue.`);
   }
 
@@ -94,10 +104,14 @@ export async function ensureNotStopped(workItemId: string, config?: TargetRepoCo
   }
 }
 
+async function projectIdForWorkItem(store: ControllerStore, workItemId: string): Promise<string | undefined> {
+  return (await store.listWorkItems()).find((item) => item.id === workItemId)?.projectId;
+}
+
 export async function recordLoopStart(workItem: WorkItem): Promise<StageArtifact> {
   const config = await loadReleaseConfig(workItem);
   const scopedWorkItem = scopeWorkItemToProject(workItem, config);
-  await ensureNotStopped(scopedWorkItem.id, config);
+  await ensureNotStopped(scopedWorkItem.id, config, scopedWorkItem.projectId);
   const store = await getActivityStore();
   const memories = selectRelevantMemories(
     [...(await store.listMemories(scopedWorkItem.id)), ...(await loadRepoContextMemories(config, scopedWorkItem))],
@@ -214,7 +228,7 @@ export async function runAgentProposal(input: StageInput): Promise<StageArtifact
 export async function evaluateProposalGate(input: ProposalGateInput): Promise<StageArtifact> {
   const config = await loadReleaseConfig(input.workItem);
   const scopedWorkItem = scopeWorkItemToProject(input.workItem, config);
-  await ensureNotStopped(scopedWorkItem.id, config);
+  await ensureNotStopped(scopedWorkItem.id, config, scopedWorkItem.projectId);
   const store = await getActivityStore();
   const githubMcpWriteEnabled = hasGithubWriteIntegration(config);
   const autoAccept =
@@ -290,7 +304,7 @@ export function hasGithubWriteIntegration(config: TargetRepoConfig): boolean {
 export async function recordProposalDecision(input: WorkflowProposalDecisionInput): Promise<StageArtifact> {
   const config = await loadReleaseConfig(input.workItem);
   const scopedWorkItem = scopeWorkItemToProject(input.workItem, config);
-  await ensureNotStopped(scopedWorkItem.id, config);
+  await ensureNotStopped(scopedWorkItem.id, config, scopedWorkItem.projectId);
   const store = await getActivityStore();
   const accepted = input.decision === "accept";
   const revising = input.decision === "revise";
@@ -378,7 +392,7 @@ async function runAgentWithTeamContext(
   const store = await getActivityStore();
   const baseConfig = await loadReleaseConfig(input.workItem);
   const scopedWorkItem = scopeWorkItemToProject(input.workItem, baseConfig);
-  await ensureNotStopped(scopedWorkItem.id, baseConfig);
+  await ensureNotStopped(scopedWorkItem.id, baseConfig, scopedWorkItem.projectId);
   const loadedPlugins = await initializePlugins(baseConfig);
   const config = mergePluginContributions(baseConfig, loadedPlugins);
   try {
@@ -440,6 +454,7 @@ async function runAgentWithTeamContext(
 export async function closeWorkLoop(workItem: WorkItem, previousArtifacts: StageArtifact[]): Promise<StageArtifact> {
   const config = await loadReleaseConfig(workItem);
   const scopedWorkItem = scopeWorkItemToProject(workItem, config);
+  await ensureNotStopped(scopedWorkItem.id, config, scopedWorkItem.projectId);
   const evidence = await collectLoopEvidence(scopedWorkItem, config);
   const release = [...previousArtifacts].reverse().find((artifact) => artifact.stage === "RELEASE");
   const priorBlocked = previousArtifacts.some(
@@ -549,7 +564,7 @@ export async function releaseWorkflowClaim(workItemId: string): Promise<void> {
 export async function prepareBuildBranches(workItem: WorkItem): Promise<{ branchPrefix: string }> {
   const config = await loadReleaseConfig(workItem);
   const scopedWorkItem = scopeWorkItemToProject(workItem, config);
-  await ensureNotStopped(scopedWorkItem.id, config);
+  await ensureNotStopped(scopedWorkItem.id, config, scopedWorkItem.projectId);
   return { branchPrefix: automationBranchPrefix(scopedWorkItem) };
 }
 
@@ -559,7 +574,7 @@ export async function integrateBranches(
 ): Promise<StageArtifact> {
   const config = await loadReleaseConfig(workItem);
   const scopedWorkItem = scopeWorkItemToProject(workItem, config);
-  await ensureNotStopped(scopedWorkItem.id, config);
+  await ensureNotStopped(scopedWorkItem.id, config, scopedWorkItem.projectId);
   const artifact = StageArtifactSchema.parse({
     workItemId: scopedWorkItem.id,
     projectId: scopedWorkItem.projectId,
@@ -599,7 +614,7 @@ export async function integrateBranches(
 export async function runVerification(workItem: WorkItem, previousArtifacts: StageArtifact[]): Promise<StageArtifact> {
   const config = await loadReleaseConfig(workItem);
   const scopedWorkItem = scopeWorkItemToProject(workItem, config);
-  await ensureNotStopped(scopedWorkItem.id, config);
+  await ensureNotStopped(scopedWorkItem.id, config, scopedWorkItem.projectId);
   const checks = await runConfiguredChecks(config, ["install", "lint", "typecheck", "test", "build", "security"]);
   const failedChecks = checks.filter((check) => !check.ok);
   const rollbackDecision = [
@@ -659,7 +674,7 @@ export async function runVerification(workItem: WorkItem, previousArtifacts: Sta
 export async function planVerification(workItem: WorkItem, previousArtifacts: StageArtifact[]): Promise<StageArtifact> {
   const config = await loadReleaseConfig(workItem);
   const scopedWorkItem = scopeWorkItemToProject(workItem, config);
-  await ensureNotStopped(scopedWorkItem.id, config);
+  await ensureNotStopped(scopedWorkItem.id, config, scopedWorkItem.projectId);
   const artifact = StageArtifactSchema.parse({
     workItemId: scopedWorkItem.id,
     projectId: scopedWorkItem.projectId,
@@ -704,7 +719,7 @@ export async function performAutonomousRelease(
 ): Promise<StageArtifact> {
   const baseConfig = await loadReleaseConfig(workItem);
   const scopedWorkItem = scopeWorkItemToProject(workItem, baseConfig);
-  await ensureNotStopped(scopedWorkItem.id, baseConfig);
+  await ensureNotStopped(scopedWorkItem.id, baseConfig, scopedWorkItem.projectId);
   const loadedPlugins = await initializePlugins(baseConfig);
   const config = mergePluginContributions(baseConfig, loadedPlugins);
   try {
@@ -1007,7 +1022,9 @@ async function collectReleaseSignal(
     readGitHubActionsEvidence(config)
   ]);
   const sync = evaluateGitSync(gitSyncInput);
-  const status = await (await getActivityStore()).getStatus();
+  const emergencyStop = await (
+    await getActivityStore()
+  ).getEmergencyStop(workItem.projectId || projectIdForConfig(config));
   const verificationPassed = previousArtifacts.some(
     (artifact) => artifact.stage === "VERIFY" && artifact.status === "passed" && artifact.releaseReadiness === "ready"
   );
@@ -1026,7 +1043,7 @@ async function collectReleaseSignal(
       secretScanPassed: envFlag("AGENT_SECRET_SCAN_PASSED") || securityPassed,
       rollbackPlanPresent: envFlag("AGENT_ROLLBACK_PLAN_PRESENT") || rollbackPlanPresent,
       releaseProofPresent: await hasReleaseProof(workItem, config, releaseTag),
-      emergencyStopActive: status.system.emergencyStop,
+      emergencyStopActive: emergencyStop.active,
       riskLevel: workItem.riskLevel,
       releaseClass: workItem.releaseClass || "code"
     },

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -302,6 +302,7 @@ export type AgentEvent = z.infer<typeof AgentEventSchema>;
 
 export const EmergencyControlRequestSchema = z.object({
   scope: z.string().trim().min(1).default("global"),
+  projectId: z.string().trim().min(1).optional(),
   reason: z.string().trim().min(1)
 });
 

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -300,11 +300,26 @@ export const AgentEventSchema = z.object({
 
 export type AgentEvent = z.infer<typeof AgentEventSchema>;
 
-export const EmergencyControlRequestSchema = z.object({
-  scope: z.string().trim().min(1).default("global"),
-  projectId: z.string().trim().min(1).optional(),
-  reason: z.string().trim().min(1)
-});
+const EmergencyControlRequestUnionSchema = z.discriminatedUnion("scope", [
+  z
+    .object({
+      scope: z.literal("global"),
+      reason: z.string().trim().min(1)
+    })
+    .strict(),
+  z.object({
+    scope: z.literal("project"),
+    projectId: z.string().trim().min(1),
+    reason: z.string().trim().min(1)
+  })
+]);
+
+export const EmergencyControlRequestSchema = z.preprocess((value) => {
+  if (value && typeof value === "object" && !Array.isArray(value) && !("scope" in value)) {
+    return { ...value, scope: "global" };
+  }
+  return value;
+}, EmergencyControlRequestUnionSchema);
 
 export type EmergencyControlRequest = z.infer<typeof EmergencyControlRequestSchema>;
 

--- a/tests/config-schema.test.ts
+++ b/tests/config-schema.test.ts
@@ -123,6 +123,13 @@ describe("target repo config schema", () => {
       scope: "global",
       reason: "Operator stop"
     });
+    expect(
+      EmergencyControlRequestSchema.parse({ scope: "project", projectId: "acme-app", reason: "Pause one repo" })
+    ).toEqual({
+      scope: "project",
+      projectId: "acme-app",
+      reason: "Pause one repo"
+    });
     expect(() => EmergencyControlRequestSchema.parse({ scope: "global", reason: " " })).toThrow();
   });
 

--- a/tests/config-schema.test.ts
+++ b/tests/config-schema.test.ts
@@ -131,6 +131,11 @@ describe("target repo config schema", () => {
       reason: "Pause one repo"
     });
     expect(() => EmergencyControlRequestSchema.parse({ scope: "global", reason: " " })).toThrow();
+    expect(() => EmergencyControlRequestSchema.parse({ scope: "glboal", reason: "Typo" })).toThrow();
+    expect(() => EmergencyControlRequestSchema.parse({ scope: "project", reason: "Missing project" })).toThrow();
+    expect(() =>
+      EmergencyControlRequestSchema.parse({ scope: "global", projectId: "acme-app", reason: "Wrong scope" })
+    ).toThrow();
   });
 
   it("keeps project connection defaults explicit and repo scoped", () => {

--- a/tests/controller-api-contract.test.ts
+++ b/tests/controller-api-contract.test.ts
@@ -3,18 +3,20 @@ import type { Socket } from "node:net";
 import { Duplex } from "node:stream";
 import type { Express } from "express";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { ControllerStore } from "../apps/controller/src/store";
 
 type CapturedResponse = { status: number; contentType: string; body: Record<string, unknown> };
 type HeaderValue = number | string | readonly string[];
 
 let app: Express;
+let controllerStore: ControllerStore;
 
 beforeAll(async () => {
   vi.stubEnv("NODE_ENV", "test");
   vi.stubEnv("DATABASE_URL", "");
   vi.stubEnv("AGENT_TEAM_CONFIG", "__missing_agent_team_config_for_controller_api_contract_tests__.yaml");
   vi.stubEnv("AGENT_TEAM_ALLOW_DEFAULT_CONFIG", "");
-  ({ app } = await import("../apps/controller/src/index.js"));
+  ({ app, controllerStore } = await import("../apps/controller/src/index.js"));
 });
 
 afterAll(() => {
@@ -22,11 +24,15 @@ afterAll(() => {
 });
 
 async function postWorkItem(body: unknown): Promise<CapturedResponse> {
+  return postJson("/api/work-items", body);
+}
+
+async function postJson(url: string, body: unknown): Promise<CapturedResponse> {
   const payload = JSON.stringify(body);
   const request = new IncomingMessage(createSocket());
   Object.assign(request, {
     method: "POST",
-    url: "/api/work-items",
+    url,
     headers: {
       "content-type": "application/json",
       "content-length": String(Buffer.byteLength(payload))
@@ -109,5 +115,88 @@ describe("controller work item API contract", () => {
       status: 400
     });
     expect(String(invalidPayload.body.detail)).toContain("title");
+  });
+
+  it("blocks workflow start for the stopped project while preserving unrelated project starts", async () => {
+    await controllerStore.upsertProjectConnection({
+      projectId: "api-project-a",
+      repoOwner: "api",
+      repoName: "project-a",
+      localPath: process.cwd(),
+      active: true
+    });
+    await controllerStore.upsertProjectConnection({
+      projectId: "api-project-b",
+      repoOwner: "api",
+      repoName: "project-b",
+      localPath: process.cwd(),
+      active: true
+    });
+
+    await expect(
+      postJson("/api/emergency-stop", {
+        scope: "project",
+        projectId: "api-project-a",
+        reason: "Pause only project A"
+      })
+    ).resolves.toMatchObject({
+      status: 200,
+      body: {
+        emergencyStop: true,
+        scope: "project:api-project-a",
+        projectId: "api-project-a",
+        reason: "Pause only project A"
+      }
+    });
+
+    const stoppedProject = await postWorkItem({
+      title: "Project A work",
+      projectId: "api-project-a",
+      repo: "api/project-a"
+    });
+    expect(stoppedProject).toMatchObject({
+      status: 202,
+      body: {
+        queued: true,
+        workflowId: null,
+        reason: "Pause only project A"
+      }
+    });
+
+    const unrelatedProject = await postWorkItem({
+      title: "Project B work",
+      projectId: "api-project-b",
+      repo: "api/project-b"
+    });
+    expect(unrelatedProject.status).toBe(202);
+    expect(unrelatedProject.body).toMatchObject({
+      queued: true,
+      workflowId: null
+    });
+    expect(unrelatedProject.body.reason).toBeUndefined();
+
+    await expect(
+      postJson("/api/emergency-resume", {
+        scope: "project",
+        projectId: "api-project-a",
+        reason: "Resume project A"
+      })
+    ).resolves.toMatchObject({
+      status: 200,
+      body: {
+        emergencyStop: false,
+        scope: "project:api-project-a",
+        projectId: "api-project-a",
+        reason: "Resume project A"
+      }
+    });
+
+    const resumedProject = await postWorkItem({
+      title: "Project A work after resume",
+      projectId: "api-project-a",
+      repo: "api/project-a"
+    });
+    expect(resumedProject.status).toBe(202);
+    expect(resumedProject.body.reason).toBeUndefined();
   });
 });

--- a/tests/controller-api-contract.test.ts
+++ b/tests/controller-api-contract.test.ts
@@ -136,6 +136,20 @@ describe("controller work item API contract", () => {
     await expect(
       postJson("/api/emergency-stop", {
         scope: "project",
+        projectId: "api-project-typo",
+        reason: "Typo should not create a scoped stop"
+      })
+    ).resolves.toMatchObject({
+      status: 404,
+      body: {
+        status: 404,
+        detail: "Connected project api-project-typo was not found."
+      }
+    });
+
+    await expect(
+      postJson("/api/emergency-stop", {
+        scope: "project",
         projectId: "api-project-a",
         reason: "Pause only project A"
       })

--- a/tests/release-activities.test.ts
+++ b/tests/release-activities.test.ts
@@ -585,6 +585,9 @@ function fakeStore(connections: ProjectConnection[] = [], options: FakeStoreOpti
     async claimWorkItemForWorkflow() {
       return true;
     },
+    async claimWorkItemForWorkflowIfNotStopped() {
+      return { claimed: true };
+    },
     async listWorkflowClaims() {
       return [];
     },

--- a/tests/release-activities.test.ts
+++ b/tests/release-activities.test.ts
@@ -92,7 +92,8 @@ describe("release activities", () => {
     const configPath = path.join(tempDir, "agent-team.config.yaml");
     await fs.writeFile(configPath, configYaml(tempDir), "utf8");
     const store = fakeStore([], {
-      emergencyStopSequence: [emergencyStopStatus(false, "owner-repo"), emergencyStopStatus(true, "owner-repo")]
+      emergencyStopSequence: [emergencyStopStatus(false, "owner-repo"), emergencyStopStatus(true, "owner-repo")],
+      emergencyStopSequenceProjectId: "owner-repo"
     });
     const { performAutonomousRelease } = await loadActivities(store);
 
@@ -372,6 +373,7 @@ type FakeStoreOptions = {
   activeGlobalStop?: boolean;
   activeProjectStops?: Set<string>;
   emergencyStopSequence?: EmergencyStopStatus[];
+  emergencyStopSequenceProjectId?: string;
 };
 
 function fakeStore(connections: ProjectConnection[] = [], options: FakeStoreOptions = {}): FakeStore {
@@ -391,6 +393,9 @@ function fakeStore(connections: ProjectConnection[] = [], options: FakeStoreOpti
     },
     async getEmergencyStop(projectId?: string) {
       if (options.emergencyStopSequence?.length) {
+        if (options.emergencyStopSequenceProjectId && projectId !== options.emergencyStopSequenceProjectId) {
+          return emergencyStopStatus(false, projectId);
+        }
         const stop =
           options.emergencyStopSequence[Math.min(emergencyStopIndex, options.emergencyStopSequence.length - 1)];
         emergencyStopIndex += 1;

--- a/tests/release-activities.test.ts
+++ b/tests/release-activities.test.ts
@@ -6,6 +6,7 @@ import type { AgentEvent, ProjectConnection, StageArtifact, TargetRepoConfig, Wo
 import type {
   ControllerStore,
   Direction,
+  EmergencyStopStatus,
   LoopRun,
   Opportunity,
   OpportunityScanRunInput,
@@ -67,6 +68,49 @@ describe("release activities", () => {
     ).rejects.toThrow(/Emergency stop is active/);
 
     expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+
+  it("blocks project-scoped activities while unrelated projects remain unblocked", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-project-stop-"));
+    const { ensureNotStopped } = await loadActivities(
+      fakeStore([], { activeProjectStops: new Set(["target-project"]) })
+    );
+
+    const startedAt = Date.now();
+
+    await expect(ensureNotStopped("WI-TARGET", targetRepoConfig(tempDir), "target-project")).rejects.toThrow(
+      /Emergency stop is active/
+    );
+    await expect(ensureNotStopped("WI-OTHER", targetRepoConfig(tempDir), "other-project")).resolves.toBeUndefined();
+
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("marks the relevant project stop active in release policy signals", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-release-project-stop-"));
+    const configPath = path.join(tempDir, "agent-team.config.yaml");
+    await fs.writeFile(configPath, configYaml(tempDir), "utf8");
+    const store = fakeStore([], {
+      emergencyStopSequence: [emergencyStopStatus(false, "owner-repo"), emergencyStopStatus(true, "owner-repo")]
+    });
+    const { performAutonomousRelease } = await loadActivities(store);
+
+    process.env.AGENT_TEAM_CONFIG = configPath;
+    process.env.AGENT_LOCAL_CHECKS_PASSED = "true";
+    process.env.AGENT_GITHUB_ACTIONS_PASSED = "true";
+    process.env.AGENT_SECRET_SCAN_PASSED = "true";
+    process.env.AGENT_ROLLBACK_PLAN_PRESENT = "true";
+
+    try {
+      const artifact = await performAutonomousRelease(workItem(), [verificationArtifact()]);
+
+      expect(artifact.status).toBe("blocked");
+      expect(artifact.decisions).toContain("Emergency stop is active.");
+      await expect(fs.access(path.join(tempDir, "release.marker"))).rejects.toThrow();
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("runs rollback and blocks release when post-release health fails", async () => {
@@ -324,18 +368,37 @@ type FakeStore = ControllerStore & {
   updatedStates: Array<{ id: string; state: string }>;
 };
 
-function fakeStore(connections: ProjectConnection[] = []): FakeStore {
+type FakeStoreOptions = {
+  activeGlobalStop?: boolean;
+  activeProjectStops?: Set<string>;
+  emergencyStopSequence?: EmergencyStopStatus[];
+};
+
+function fakeStore(connections: ProjectConnection[] = [], options: FakeStoreOptions = {}): FakeStore {
   const updatedStates: Array<{ id: string; state: string }> = [];
+  let emergencyStopIndex = 0;
   return {
     updatedStates,
     async init() {},
     async getStatus() {
+      const globalStop = emergencyStopStatus(options.activeGlobalStop ?? false);
       return {
         system: {
-          emergencyStop: false,
-          emergencyReason: ""
+          emergencyStop: globalStop.active,
+          emergencyReason: globalStop.reason
         }
       } as Awaited<ReturnType<ControllerStore["getStatus"]>>;
+    },
+    async getEmergencyStop(projectId?: string) {
+      if (options.emergencyStopSequence?.length) {
+        const stop =
+          options.emergencyStopSequence[Math.min(emergencyStopIndex, options.emergencyStopSequence.length - 1)];
+        emergencyStopIndex += 1;
+        return stop;
+      }
+      if (options.activeGlobalStop) return emergencyStopStatus(true);
+      if (projectId && options.activeProjectStops?.has(projectId)) return emergencyStopStatus(true, projectId);
+      return emergencyStopStatus(false, projectId);
     },
     async listWorkItems() {
       return [];
@@ -525,6 +588,15 @@ function fakeStore(connections: ProjectConnection[] = []): FakeStore {
     async updateWorkItemState(id: string, state: string) {
       updatedStates.push({ id, state });
     }
+  };
+}
+
+function emergencyStopStatus(active: boolean, projectId?: string): EmergencyStopStatus {
+  return {
+    active,
+    reason: active ? "Scoped emergency stop" : "",
+    scope: projectId ? "project" : "global",
+    projectId
   };
 }
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -151,6 +151,23 @@ describe("controller store workflow claims", () => {
     await expect(store.listWorkflowClaims()).resolves.toEqual(["WI-1"]);
   });
 
+  it("keeps workflow claiming behind scoped emergency stops", async () => {
+    const store = new MemoryStore();
+
+    await store.setEmergencyStop(true, "Project pause", "project-a");
+    await expect(store.claimWorkItemForWorkflowIfNotStopped("WI-1", "project-a")).resolves.toMatchObject({
+      claimed: false,
+      emergencyStop: {
+        active: true,
+        reason: "Project pause",
+        scope: "project",
+        projectId: "project-a"
+      }
+    });
+    await expect(store.listWorkflowClaims()).resolves.toEqual([]);
+    await expect(store.claimWorkItemForWorkflowIfNotStopped("WI-2", "project-b")).resolves.toEqual({ claimed: true });
+  });
+
   it("stores stage events with increasing sequence numbers", async () => {
     const store = new MemoryStore();
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -3,6 +3,7 @@ import {
   MemoryStore,
   PostgresStore,
   type ControllerStore,
+  type EmergencyStopStatus,
   type StrictProjectScope
 } from "../apps/controller/src/store";
 import {
@@ -96,6 +97,49 @@ async function expectLatestEventBackfill(store: ControllerStore, workItemPrefix 
   await expect(store.listEvents(0, 0)).resolves.toEqual([]);
 }
 
+async function expectScopedEmergencyStopLifecycle(store: ControllerStore, projectId = "project-a") {
+  await store.setEmergencyStop(false, "Reset global stop");
+  await store.setEmergencyStop(false, "Reset project stop", projectId);
+  await store.setEmergencyStop(false, "Reset other project stop", "project-b");
+
+  await store.setEmergencyStop(true, "Global stop");
+  await store.setEmergencyStop(true, "Project A stop", projectId);
+
+  await expect(store.getEmergencyStop(projectId)).resolves.toMatchObject({
+    active: true,
+    reason: "Global stop",
+    scope: "global"
+  } satisfies Partial<EmergencyStopStatus>);
+
+  await store.setEmergencyStop(false, "Resume global");
+
+  await expect(store.getEmergencyStop(projectId)).resolves.toMatchObject({
+    active: true,
+    reason: "Project A stop",
+    scope: "project",
+    projectId
+  } satisfies Partial<EmergencyStopStatus>);
+  await expect(store.getEmergencyStop("project-b")).resolves.toMatchObject({
+    active: false,
+    scope: "project",
+    projectId: "project-b"
+  } satisfies Partial<EmergencyStopStatus>);
+  await expect(store.getStatus()).resolves.toMatchObject({
+    system: {
+      emergencyStop: false,
+      emergencyReason: ""
+    }
+  });
+
+  await store.setEmergencyStop(false, "Resume project", projectId);
+
+  await expect(store.getEmergencyStop(projectId)).resolves.toMatchObject({
+    active: false,
+    scope: "project",
+    projectId
+  } satisfies Partial<EmergencyStopStatus>);
+}
+
 describe("controller store workflow claims", () => {
   it("prevents duplicate workflow claims for the same item", async () => {
     const store = new MemoryStore();
@@ -134,6 +178,11 @@ describe("controller store workflow claims", () => {
   it("returns the latest event backfill in ascending sequence order", async () => {
     const store = new MemoryStore();
     await expectLatestEventBackfill(store);
+  });
+
+  it("stores global and project emergency stops independently in memory", async () => {
+    const store = new MemoryStore();
+    await expectScopedEmergencyStopLifecycle(store);
   });
 
   it("filters events by projectId and excludes unscoped events", async () => {
@@ -359,6 +408,24 @@ describe("controller store workflow claims", () => {
         await store.init();
         await expectLatestEventBackfill(store, `WI-EVENT-PG-${process.pid}-${Date.now()}`);
       } finally {
+        await store.close();
+      }
+    }
+  );
+
+  it.skipIf(!process.env.POSTGRES_TEST_DATABASE_URL)(
+    "stores global and project emergency stops independently in Postgres",
+    async () => {
+      const connectionString = process.env.POSTGRES_TEST_DATABASE_URL;
+      if (!connectionString) throw new Error("POSTGRES_TEST_DATABASE_URL is required for this test.");
+      const store = new PostgresStore(connectionString);
+      const projectId = `project-stop-${process.pid}-${Date.now()}`;
+      try {
+        await store.init();
+        await expectScopedEmergencyStopLifecycle(store, projectId);
+      } finally {
+        await store.setEmergencyStop(false, "Cleanup global").catch(() => undefined);
+        await store.setEmergencyStop(false, "Cleanup project", projectId).catch(() => undefined);
         await store.close();
       }
     }


### PR DESCRIPTION
## Summary

Codex Cloud Backend/Core implemented queued issue #105.

Closes #105

## Scope

[Codex Queue] Add project-scoped emergency stop enforcement

## Validation

- npm run check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- git diff --check

## Automation

- Stage: Backend/Core
- Run: https://github.com/onfire7777/five-agent-dev-team/actions/runs/25351743216
- Target: #105


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emergency stop/resume now support project-level targeting and return both scope and projectId.
* **Behavior**
  * Workflow starts and release checks respect project-scoped stops (only the targeted project is blocked).
  * Stopping an unknown project now yields a not-found response.
* **Schema**
  * API validation requires projectId when scope is "project" (defaults to global when omitted).
* **Tests**
  * Expanded contract and unit tests cover scoped emergency-stop lifecycles and API behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->