### PR TITLE
Pause cloud automation on Codex provider failures

### DIFF
--- a/.github/workflows/codex-cloud-build-pipeline.yml
+++ b/.github/workflows/codex-cloud-build-pipeline.yml
@@ -491,6 +491,94 @@ jobs:
             Expected verification before PR publication:
             ${{ steps.gate.outputs.verify_hint }}
 
+      - name: Pause pipeline on Codex provider failure
+        id: provider_failure_pause
+        if: steps.gate.outputs.should_run == 'true' && steps.gate.outputs.target_kind == 'issue' && steps.run_codex.outcome == 'failure'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const issue_number = Number("${{ steps.gate.outputs.target_number }}");
+            const { owner, repo } = context.repo;
+            const healthTitle = "[Codex Health] Cloud control-plane finding";
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const labels = ["agent:blocked", "blocker:global-stop"];
+            let cleanupError = null;
+
+            try {
+              const body = [
+                "# Codex Cloud Meta Health",
+                "",
+                `Observed: ${new Date().toISOString()}`,
+                `Repository: ${owner}/${repo}`,
+                "",
+                "## Blockers",
+                `- globalStop: Codex provider call failed during ${{ steps.gate.outputs.stage_display }}.`,
+                "",
+                "## Evidence",
+                "- Workflow: Codex Cloud Build Pipeline",
+                `- Stage: ${{ steps.gate.outputs.stage }}`,
+                `- Queue issue: #${issue_number}`,
+                `- Run: ${runUrl}`,
+                "- The Codex action failed before a verified implementation PR could be published. Treat this as an OpenAI provider/auth/quota issue until a forced cloud research or lane run succeeds.",
+                "",
+                "## Required action",
+                "- Verify OPENAI_API_KEY, OpenAI project billing, project limits, and model access.",
+                "- After fixing credentials or quota, run Codex Cloud Research manually with force=true, then run Meta Health to clear this pause.",
+                "",
+                "## Routing",
+                "Cloud build lanes should remain paused by this global stop issue."
+              ].join("\n");
+              const openIssuesRaw = await github.paginate(github.rest.issues.listForRepo, {
+                owner,
+                repo,
+                state: "open",
+                per_page: 100
+              });
+              const healthIssue = openIssuesRaw.find((issue) => !issue.pull_request && issue.title === healthTitle);
+              if (healthIssue) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: healthIssue.number,
+                  body,
+                  labels
+                });
+              } else {
+                await github.rest.issues.create({
+                  owner,
+                  repo,
+                  title: healthTitle,
+                  body,
+                  labels
+                });
+              }
+            } catch (error) {
+              core.error(`Unexpected provider-failure pause error: ${error.status || "unknown"} ${error.message}`);
+              throw error;
+            } finally {
+              try {
+                await github.rest.issues.addLabels({ owner, repo, issue_number, labels });
+                for (const label of ["agent:running", "agent:claimed"]) {
+                  try {
+                    await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label });
+                  } catch {}
+                }
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body: `Codex provider failure paused the cloud automation pipeline before this item could finish.\n\nRun: ${runUrl}`
+                });
+              } catch (error) {
+                cleanupError = error;
+                core.error(`Provider-failure queue cleanup failed: ${error.status || "unknown"} ${error.message}`);
+              }
+            }
+
+            if (cleanupError) throw cleanupError;
+            core.setOutput("handled", "true");
+            core.setFailed("Codex provider failure paused cloud automation.");
+
       - name: Detect generated changes
         id: changes
         if: steps.gate.outputs.should_run == 'true' && steps.gate.outputs.target_kind == 'issue'
@@ -748,7 +836,7 @@ jobs:
               .write();
 
       - name: Route failed issue
-        if: failure() && steps.gate.outputs.target_kind == 'issue'
+        if: failure() && steps.gate.outputs.target_kind == 'issue' && steps.provider_failure_pause.outputs.handled != 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |

--- a/.github/workflows/codex-cloud-meta-health.yml
+++ b/.github/workflows/codex-cloud-meta-health.yml
@@ -37,6 +37,7 @@ jobs:
             const now = new Date().toISOString();
             const blockers = [];
             const warnings = [];
+            const healthTitle = "[Codex Health] Cloud control-plane finding";
 
             const branch = await github.rest.repos.getBranch({ owner, repo, branch: "main" });
             const mainSha = branch.data.commit.sha;
@@ -208,6 +209,7 @@ jobs:
                 ["agent:queued", "agent:claimed", "agent:running", "agent:merge-gate"].includes(label.name)
               )
             );
+            const healthIssues = openIssues.filter((issue) => issue.title === healthTitle);
             const laneOrder = ["backend", "frontend", "quality", "security", "docs"];
             const issueField = (issue, name) =>
               (issue.body || "").match(new RegExp(`^${name}:\\s*(.+)$`, "im"))?.[1]?.toLowerCase() || "";
@@ -312,7 +314,13 @@ jobs:
               });
             }
 
-            if (!blockingOpenPrs.length && !queueIssues.length && retryableBlockedIssues.length) {
+            if (
+              !blockers.length &&
+              !healthIssues.length &&
+              !blockingOpenPrs.length &&
+              !queueIssues.length &&
+              retryableBlockedIssues.length
+            ) {
               const { issue, lane } = retryableBlockedIssues[0];
               const labels = labelNamesFor(issue);
               await github.rest.issues.addLabels({
@@ -375,8 +383,6 @@ jobs:
               });
             }
 
-            const healthTitle = "[Codex Health] Cloud control-plane finding";
-            const healthIssues = openIssues.filter((issue) => issue.title === healthTitle);
             const requiredLine = requiredContexts.length ? requiredContexts.join(", ") : "none reported";
             const summary = [
               "# Codex Cloud Meta Health",

--- a/.github/workflows/codex-cloud-research.yml
+++ b/.github/workflows/codex-cloud-research.yml
@@ -77,6 +77,21 @@ jobs:
               state: "open",
               per_page: 100
             });
+            const openIssues = openIssuesRaw.filter((issue) => !issue.pull_request);
+            const globalStop = openIssues.find((issue) => {
+              const labels = issue.labels.map((label) => label.name);
+              return (
+                issue.title.startsWith("[Codex Health]") &&
+                labels.includes("agent:blocked") &&
+                labels.includes("blocker:global-stop")
+              );
+            });
+            if (globalStop && !force) {
+              return finish({
+                run: false,
+                reason: `skipped: global stop issue #${globalStop.number}: ${globalStop.title}`
+              });
+            }
             const activeQueueIssues = openIssuesRaw
               .filter((issue) => !issue.pull_request)
               .filter((issue) =>
@@ -176,6 +191,62 @@ jobs:
             Lane assignment: <backend|frontend|quality|security|docs>
             Execution target: <codex-cloud|codex-action|agentic-workflow>
             Score: <22-30>/30
+
+      - name: Pause pipeline on Codex provider failure
+        if: failure() && steps.run_codex.outcome == 'failure'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const healthTitle = "[Codex Health] Cloud control-plane finding";
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const body = [
+              "# Codex Cloud Meta Health",
+              "",
+              `Observed: ${new Date().toISOString()}`,
+              `Repository: ${owner}/${repo}`,
+              "",
+              "## Blockers",
+              "- globalStop: Codex provider call failed during Stage 0 R&D.",
+              "",
+              "## Evidence",
+              `- Workflow: Codex Cloud Research`,
+              `- Run: ${runUrl}`,
+              "- The Codex action failed before producing a valid queue item. Treat this as an OpenAI provider/auth/quota issue until a forced research run succeeds.",
+              "",
+              "## Required action",
+              "- Verify OPENAI_API_KEY, OpenAI project billing, project limits, and model access.",
+              "- After fixing credentials or quota, run Codex Cloud Research manually with force=true, then run Meta Health to clear this pause.",
+              "",
+              "## Routing",
+              "Cloud build lanes should remain paused by this global stop issue."
+            ].join("\n");
+            const openIssuesRaw = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100
+            });
+            const healthIssue = openIssuesRaw.find((issue) => !issue.pull_request && issue.title === healthTitle);
+            const labels = ["agent:blocked", "blocker:global-stop"];
+            if (healthIssue) {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: healthIssue.number,
+                body,
+                labels
+              });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: healthTitle,
+                body,
+                labels
+              });
+            }
+            core.setFailed("Codex provider failure paused cloud automation.");
 
       - name: Create or refresh queue issue
         id: queue_issue

--- a/tests/cloud-automation-health.test.mjs
+++ b/tests/cloud-automation-health.test.mjs
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+
+function workflow(name) {
+  return readFileSync(join(root, ".github", "workflows", name), "utf8");
+}
+
+describe("cloud automation health policy", () => {
+  it("keeps scheduled research behind the global health stop", () => {
+    const research = workflow("codex-cloud-research.yml");
+
+    expect(research).toContain("global stop issue #");
+    expect(research).toContain('labels.includes("agent:blocked")');
+    expect(research).toContain('labels.includes("blocker:global-stop")');
+    expect(research).toContain("Pause pipeline on Codex provider failure");
+  });
+
+  it("turns Codex provider failures into global stops before lane retry routing", () => {
+    const build = workflow("codex-cloud-build-pipeline.yml");
+
+    expect(build).toContain("Pause pipeline on Codex provider failure");
+    expect(build).toContain("steps.provider_failure_pause.outputs.handled != 'true'");
+    expect(build).toContain('core.setOutput("handled", "true")');
+    expect(build).toContain('const labels = ["agent:blocked", "blocker:global-stop"]');
+  });
+
+  it("prevents Meta Health from requeuing lane stops while a global stop is active", () => {
+    const meta = workflow("codex-cloud-meta-health.yml");
+
+    expect(meta).toContain('const healthTitle = "[Codex Health] Cloud control-plane finding"');
+    expect(meta).toContain("!blockers.length");
+    expect(meta).toContain("!healthIssues.length");
+    expect(meta).toContain("Retryable blocked lane-stop issues");
+  });
+});


### PR DESCRIPTION
## Summary
- turn Codex action provider/auth/quota failures into a global cloud health stop
- make scheduled research respect the global health stop unless explicitly forced
- prevent Meta Health from requeuing lane-stop work while a global stop is active
- add workflow policy coverage for the pause behavior

## Validation
- npm test -- tests/cloud-automation-health.test.mjs tests/preflight-policy.test.mjs
- npm run format:check -- tests/cloud-automation-health.test.mjs .github/workflows/codex-cloud-research.yml .github/workflows/codex-cloud-build-pipeline.yml .github/workflows/codex-cloud-meta-health.yml
- git diff --check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- npm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global stop that creates/updates a central health issue and pauses pipelines on provider failures, with remediation guidance.

* **Bug Fixes**
  * Prevented duplicate routing for the same failure by gating subsequent routing when a global stop is handled.
  * Fixed timing of health checks to avoid duplicate health issue detection.

* **Tests**
  * Added tests validating health policy behavior and failure-handling workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->