### PR TITLE
Preserve cloud global stop until provider verifies

### DIFF
--- a/.github/workflows/codex-cloud-meta-health.yml
+++ b/.github/workflows/codex-cloud-meta-health.yml
@@ -210,6 +210,14 @@ jobs:
               )
             );
             const healthIssues = openIssues.filter((issue) => issue.title === healthTitle);
+            for (const issue of healthIssues) {
+              blockers.push({
+                class: "globalStop",
+                title: `Existing cloud health stop #${issue.number} remains active`,
+                detail:
+                  "Meta Health will preserve this pause until a successful forced Codex Cloud Research run verifies the provider and closes the health issue."
+              });
+            }
             const laneOrder = ["backend", "frontend", "quality", "security", "docs"];
             const issueField = (issue, name) =>
               (issue.body || "").match(new RegExp(`^${name}:\\s*(.+)$`, "im"))?.[1]?.toLowerCase() || "";

--- a/.github/workflows/codex-cloud-research.yml
+++ b/.github/workflows/codex-cloud-research.yml
@@ -350,7 +350,7 @@ jobs:
             core.setOutput("lane", lane);
 
       - name: Clear provider global stop after successful forced research
-        if: steps.run_codex.outcome == 'success' && (github.event.inputs.force == 'true' || github.event.inputs.force == true)
+        if: always() && steps.run_codex.outcome == 'success' && (github.event.inputs.force == 'true' || github.event.inputs.force == true)
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
@@ -364,11 +364,7 @@ jobs:
               per_page: 100
             });
             const healthIssues = openIssuesRaw
-              .filter((issue) => !issue.pull_request && issue.title === healthTitle)
-              .filter((issue) => {
-                const labels = issue.labels.map((label) => label.name);
-                return labels.includes("agent:blocked") && labels.includes("blocker:global-stop");
-              });
+              .filter((issue) => !issue.pull_request && issue.title === healthTitle);
 
             for (const issue of healthIssues) {
               await github.rest.issues.createComment({

--- a/.github/workflows/codex-cloud-research.yml
+++ b/.github/workflows/codex-cloud-research.yml
@@ -349,6 +349,43 @@ jobs:
             core.setOutput("issue_number", String(created.data.number));
             core.setOutput("lane", lane);
 
+      - name: Clear provider global stop after successful forced research
+        if: steps.run_codex.outcome == 'success' && (github.event.inputs.force == 'true' || github.event.inputs.force == true)
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const healthTitle = "[Codex Health] Cloud control-plane finding";
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const openIssuesRaw = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100
+            });
+            const healthIssues = openIssuesRaw
+              .filter((issue) => !issue.pull_request && issue.title === healthTitle)
+              .filter((issue) => {
+                const labels = issue.labels.map((label) => label.name);
+                return labels.includes("agent:blocked") && labels.includes("blocker:global-stop");
+              });
+
+            for (const issue of healthIssues) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: `Codex Cloud Research completed successfully with force=true, so the provider/auth/quota global stop is verified clear.\n\nRun: ${runUrl}`
+              });
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issue.number,
+                state: "closed",
+                state_reason: "completed"
+              });
+            }
+
       - name: Dispatch build for queued issue
         if: steps.queue_issue.outputs.queue_ready == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b

--- a/tests/cloud-automation-health.test.mjs
+++ b/tests/cloud-automation-health.test.mjs
@@ -16,6 +16,7 @@ describe("cloud automation health policy", () => {
     expect(research).toContain('labels.includes("agent:blocked")');
     expect(research).toContain('labels.includes("blocker:global-stop")');
     expect(research).toContain("Pause pipeline on Codex provider failure");
+    expect(research).toContain("Clear provider global stop after successful forced research");
   });
 
   it("turns Codex provider failures into global stops before lane retry routing", () => {
@@ -31,6 +32,7 @@ describe("cloud automation health policy", () => {
     const meta = workflow("codex-cloud-meta-health.yml");
 
     expect(meta).toContain('const healthTitle = "[Codex Health] Cloud control-plane finding"');
+    expect(meta).toContain("Existing cloud health stop #");
     expect(meta).toContain("!blockers.length");
     expect(meta).toContain("!healthIssues.length");
     expect(meta).toContain("Retryable blocked lane-stop issues");

--- a/tests/cloud-automation-health.test.mjs
+++ b/tests/cloud-automation-health.test.mjs
@@ -17,6 +17,8 @@ describe("cloud automation health policy", () => {
     expect(research).toContain('labels.includes("blocker:global-stop")');
     expect(research).toContain("Pause pipeline on Codex provider failure");
     expect(research).toContain("Clear provider global stop after successful forced research");
+    expect(research).toContain("always() && steps.run_codex.outcome == 'success'");
+    expect(research).toContain(".filter((issue) => !issue.pull_request && issue.title === healthTitle)");
   });
 
   it("turns Codex provider failures into global stops before lane retry routing", () => {


### PR DESCRIPTION
## Summary
- keep existing cloud health global-stop issues active in Meta Health instead of closing them after skipped research runs
- clear the provider global-stop only after a successful forced Codex Cloud Research run
- extend policy tests for the pause and verified-clear behavior

## Validation
- npm test -- tests/cloud-automation-health.test.mjs tests/preflight-policy.test.mjs
- npm run check
- npm run logs:check
- docker compose config --no-interpolate --quiet
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic verification and closure of cloud "health" issues after successful forced research runs.

* **Bug Fixes**
  * Existing cloud health issues are now treated as active global blockers to avoid unintended closure and ensure proper blocker handling.

* **Tests**
  * Expanded test coverage to validate the new verification/closure behavior and blocker detection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->