### PR TITLE
Pause all automation surfaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    # Paused by operator request. Restore a positive limit when re-enabling.
+    open-pull-requests-limit: 0
     groups:
       dev-tooling:
         dependency-type: development
@@ -14,3 +15,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Paused by operator request. Restore a positive limit when re-enabling.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary\n\nPauses the remaining Dependabot automation surface by setting Dependabot PR limits to 0 for npm and GitHub Actions updates.\n\n## Validation\n\n- git diff --check\n- docker compose config --no-interpolate --quiet\n\n## Notes\n\nAll GitHub Actions workflows are disabled manually. Local Codex automations are paused. Docker Compose services are stopped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Paused automated dependency update checks. Updates can be re-enabled in the future when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->